### PR TITLE
Apply MCP design guidelines P0: adaptive status, agent hints, structured errors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,13 @@ The `config.py` module uses Pydantic Settings for type-safe configuration with a
 - Proper MCP error responses with structured error information
 - Request timeout handling and retry logic in gateway client
 
+### Agent Guidance (MCP Design Guidelines P0)
+- **Adaptive health_check**: Returns `ready` boolean, `_recommendations`, and contextual `_next` based on stamp availability
+- **Response hints**: All success responses append `_next: <tool>` and `_related: <tools>` guiding agents to the logical next step
+- **Structured errors**: All error responses include `retryable: true|false` and `_next` recovery hint
+- **Typo correction**: Unknown tool names get Levenshtein-based "Did you mean?" suggestions
+- Helper functions: `_format_hints()`, `_format_error()`, `_is_retryable_error()`, `_suggest_tool_name()`
+
 ### Code Quality
 - Black formatting with 88-character line length
 - Ruff linting with comprehensive rule set (ignores specific rules for MCP compatibility)

--- a/MCP_usage_ecosystem.md
+++ b/MCP_usage_ecosystem.md
@@ -120,6 +120,40 @@ Our Swarm Provenance MCP server currently provides these tools:
 - `get_notary_info` - Check notary signing service availability
 - `health_check` - Verify gateway and network connectivity
 
+## 🧭 Agent Workflow Guidance
+
+The MCP server includes built-in guidance to help AI agents chain operations correctly:
+
+### Response Hints
+
+Every successful tool response includes `_next` and `_related` hints:
+
+```
+_next: upload_data                    # Recommended next tool
+_related: check_stamp_health, list_stamps  # Other relevant tools
+```
+
+Hints are **contextual** — they adapt based on the result:
+- `list_stamps` with usable stamps → `_next: upload_data`
+- `list_stamps` with no stamps → `_next: purchase_stamp`
+- `check_stamp_health` healthy → `_next: upload_data`
+- `check_stamp_health` unhealthy → `_next: purchase_stamp`
+
+### Structured Errors
+
+Error responses include recovery guidance:
+- `retryable: true` — transient errors (timeouts, rate limits), safe to retry
+- `retryable: false` — permanent errors (validation), fix input and try different approach
+- `_next: <tool>` — recovery tool suggestion
+
+### Adaptive Health Check
+
+`health_check` proactively checks both gateway connectivity and stamp availability:
+- `ready: true` — system is fully ready for uploads
+- `ready: false` + `_recommendations` — explains what's needed before uploading
+
+This allows agents to call `health_check` once and immediately know what to do next.
+
 ## 🔗 Integration Examples
 
 ### **Research Workflow:**

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ Check whether the notary signing service is enabled and available on the gateway
 ```
 
 #### `health_check`
-Check gateway and Swarm network connectivity status.
+Check gateway and Swarm network connectivity status. Returns an adaptive status including stamp availability, a `ready` flag indicating whether uploads can proceed, and recommendations for next steps.
 
 **Parameters:** None
 
@@ -301,6 +301,43 @@ Check gateway and Swarm network connectivity status.
   "name": "health_check",
   "arguments": {}
 }
+```
+
+### Response Format
+
+All tool responses include structured metadata to help agents chain operations efficiently:
+
+#### Success Responses
+
+Every successful response appends workflow hints:
+
+```
+_next: <recommended_tool>        # The logical next tool to call
+_related: <tool1>, <tool2>       # Other relevant tools
+```
+
+Hints are contextual — for example, `list_stamps` suggests `_next: upload_data` when usable stamps exist, but `_next: purchase_stamp` when none are available.
+
+#### Error Responses
+
+Error responses include structured recovery information:
+
+```
+retryable: true|false            # Whether retrying the same call may succeed
+_next: <recovery_tool>           # Tool to call for recovery
+```
+
+- **retryable: true** — transient errors (timeouts, rate limits, 502/503/504). Wait and retry.
+- **retryable: false** — permanent errors (validation failures, unknown tools). Fix input and try a different approach.
+
+#### Adaptive Health Check
+
+The `health_check` tool returns additional fields:
+
+```
+ready: true|false                # Whether the system is ready for uploads
+_recommendations:                # Actionable suggestions (only when issues exist)
+  - No stamps found — purchase one before uploading
 ```
 
 ## Docker

--- a/swarm_provenance_mcp/server.py
+++ b/swarm_provenance_mcp/server.py
@@ -223,10 +223,12 @@ def _format_error(message: str, retryable: bool, next_tool: Optional[str] = None
 
 def _is_retryable_error(e: Exception) -> bool:
     """Determine if an exception represents a transient, retryable error."""
+    from requests.exceptions import ConnectionError as ReqConnectionError, Timeout
+    if isinstance(e, (ReqConnectionError, Timeout)):
+        return True
     if isinstance(e, RequestException) and hasattr(e, 'response') and e.response is not None:
         return e.response.status_code in (408, 429, 502, 503, 504)
     if isinstance(e, RequestException):
-        # Connection errors are generally retryable
         error_str = str(e).lower()
         return any(w in error_str for w in ('timeout', 'connection', 'connect'))
     return False

--- a/tests/test_tool_execution.py
+++ b/tests/test_tool_execution.py
@@ -378,6 +378,344 @@ class TestToolExecution:
                     pytest.fail(f"Tool {tool_name} returned invalid JSON: {content_text}")
 
 
+class TestResponseHints:
+    """Test that tool responses include _next and _related hints."""
+
+    @pytest.fixture
+    def server(self):
+        return create_server()
+
+    @pytest.fixture
+    def mock_gateway_client(self):
+        """Mock gateway client with standard responses."""
+        with patch('swarm_provenance_mcp.server.gateway_client') as mock_client:
+            mock_client.purchase_stamp.return_value = {
+                "batchID": TEST_STAMP_ID,
+                "message": "Stamp purchased successfully"
+            }
+            mock_client.get_stamp_details.return_value = {
+                "batchID": TEST_STAMP_ID,
+                "amount": "2000000000",
+                "depth": 17,
+                "usable": True,
+                "batchTTL": 123456
+            }
+            mock_client.list_stamps.return_value = {
+                "stamps": [{"batchID": TEST_STAMP_ID, "usable": True}],
+                "total_count": 1
+            }
+            mock_client.extend_stamp.return_value = {
+                "batchID": TEST_STAMP_ID,
+                "message": "Stamp extended"
+            }
+            mock_client.upload_data.return_value = {
+                "reference": TEST_REFERENCE,
+                "message": "Upload successful"
+            }
+            mock_client.download_data.return_value = b'{"test": "data"}'
+            mock_client.check_stamp_health.return_value = {
+                "stamp_id": TEST_STAMP_ID,
+                "can_upload": True,
+                "errors": [],
+                "warnings": [],
+                "status": {"utilizationPercent": 10, "batchTTL": 86400}
+            }
+            mock_client.get_wallet_info.return_value = {
+                "walletAddress": "0x1234",
+                "bzzBalance": "5000"
+            }
+            mock_client.get_notary_info.return_value = {
+                "enabled": True,
+                "available": True,
+                "address": "0xabcdef",
+                "message": "Operational"
+            }
+            mock_client.health_check.return_value = {
+                "status": "healthy",
+                "gateway_url": "http://localhost:8000",
+                "response_time_ms": 15
+            }
+            yield mock_client
+
+    async def test_all_success_responses_have_next_hint(self, server, mock_gateway_client):
+        """Every successful tool response must include a _next hint."""
+        tools_to_test = [
+            ("purchase_stamp", {}),
+            ("get_stamp_status", {"stamp_id": TEST_STAMP_ID}),
+            ("list_stamps", {}),
+            ("extend_stamp", {"stamp_id": TEST_STAMP_ID, "amount": 2000000000}),
+            ("upload_data", {"data": "test", "stamp_id": TEST_STAMP_ID}),
+            ("download_data", {"reference": TEST_REFERENCE}),
+            ("check_stamp_health", {"stamp_id": TEST_STAMP_ID}),
+            ("get_wallet_info", {}),
+            ("get_notary_info", {}),
+            ("health_check", {}),
+        ]
+
+        for tool_name, arguments in tools_to_test:
+            result = await call_tool_directly(server, tool_name, arguments)
+            content_text = result.content[0].text
+            assert "_next:" in content_text, \
+                f"Tool '{tool_name}' success response missing _next hint"
+
+    async def test_purchase_stamp_hints(self, server, mock_gateway_client):
+        """purchase_stamp should suggest check_stamp_health next."""
+        result = await call_tool_directly(server, "purchase_stamp", {})
+        text = result.content[0].text
+        assert "_next: check_stamp_health" in text
+        assert "_related:" in text
+
+    async def test_list_stamps_hints_with_usable(self, server, mock_gateway_client):
+        """list_stamps with usable stamps should suggest upload_data."""
+        result = await call_tool_directly(server, "list_stamps", {})
+        text = result.content[0].text
+        assert "_next: upload_data" in text
+
+    async def test_list_stamps_hints_no_stamps(self, server, mock_gateway_client):
+        """list_stamps with no stamps should suggest purchase_stamp."""
+        mock_gateway_client.list_stamps.return_value = {"stamps": [], "total_count": 0}
+        result = await call_tool_directly(server, "list_stamps", {})
+        text = result.content[0].text
+        assert "_next: purchase_stamp" in text
+
+    async def test_get_stamp_status_hints_usable(self, server, mock_gateway_client):
+        """get_stamp_status for usable stamp should suggest upload_data."""
+        result = await call_tool_directly(
+            server, "get_stamp_status", {"stamp_id": TEST_STAMP_ID}
+        )
+        text = result.content[0].text
+        assert "_next: upload_data" in text
+
+    async def test_get_stamp_status_hints_not_usable(self, server, mock_gateway_client):
+        """get_stamp_status for non-usable stamp should suggest purchase_stamp."""
+        mock_gateway_client.get_stamp_details.return_value = {
+            "batchID": TEST_STAMP_ID, "usable": False, "amount": "0", "depth": 17
+        }
+        result = await call_tool_directly(
+            server, "get_stamp_status", {"stamp_id": TEST_STAMP_ID}
+        )
+        text = result.content[0].text
+        assert "_next: purchase_stamp" in text
+
+    async def test_upload_data_hints(self, server, mock_gateway_client):
+        """upload_data should suggest download_data next."""
+        result = await call_tool_directly(
+            server, "upload_data", {"data": "test", "stamp_id": TEST_STAMP_ID}
+        )
+        text = result.content[0].text
+        assert "_next: download_data" in text
+
+    async def test_check_stamp_health_hints_healthy(self, server, mock_gateway_client):
+        """Healthy stamp should suggest upload_data."""
+        result = await call_tool_directly(
+            server, "check_stamp_health", {"stamp_id": TEST_STAMP_ID}
+        )
+        text = result.content[0].text
+        assert "_next: upload_data" in text
+
+    async def test_check_stamp_health_hints_unhealthy(self, server, mock_gateway_client):
+        """Unhealthy stamp should suggest purchase_stamp."""
+        mock_gateway_client.check_stamp_health.return_value = {
+            "stamp_id": TEST_STAMP_ID,
+            "can_upload": False,
+            "errors": [{"code": "EXPIRED", "message": "Expired"}],
+            "warnings": [],
+            "status": {}
+        }
+        result = await call_tool_directly(
+            server, "check_stamp_health", {"stamp_id": TEST_STAMP_ID}
+        )
+        text = result.content[0].text
+        assert "_next: purchase_stamp" in text
+
+
+class TestStructuredErrors:
+    """Test that error responses include retryable flag and recovery hints."""
+
+    @pytest.fixture
+    def server(self):
+        return create_server()
+
+    async def test_validation_error_not_retryable(self, server):
+        """Validation errors should be marked retryable: false."""
+        with patch('swarm_provenance_mcp.server.gateway_client'):
+            result = await call_tool_directly(
+                server, "get_stamp_status", {"stamp_id": "invalid!"}
+            )
+            assert result.isError
+            text = result.content[0].text
+            assert "retryable: false" in text
+
+    async def test_network_error_retryable(self, server):
+        """Network/connection errors should be marked retryable: true."""
+        from requests.exceptions import ConnectionError
+        with patch('swarm_provenance_mcp.server.gateway_client') as mock_client:
+            mock_client.list_stamps.side_effect = ConnectionError("Connection refused")
+            result = await call_tool_directly(server, "list_stamps", {})
+            assert result.isError
+            text = result.content[0].text
+            assert "retryable: true" in text
+
+    async def test_error_includes_next_hint(self, server):
+        """Error responses should include _next recovery hint."""
+        from requests.exceptions import ConnectionError
+        with patch('swarm_provenance_mcp.server.gateway_client') as mock_client:
+            mock_client.purchase_stamp.side_effect = ConnectionError("timeout")
+            result = await call_tool_directly(server, "purchase_stamp", {})
+            assert result.isError
+            text = result.content[0].text
+            assert "_next:" in text
+
+    async def test_validation_error_suggests_correct_tool(self, server):
+        """Validation errors should suggest the right recovery tool."""
+        with patch('swarm_provenance_mcp.server.gateway_client'):
+            # Bad stamp ID → should suggest list_stamps to find valid IDs
+            result = await call_tool_directly(
+                server, "get_stamp_status", {"stamp_id": "bad"}
+            )
+            assert result.isError
+            text = result.content[0].text
+            assert "_next: list_stamps" in text
+
+
+class TestTypoCorrection:
+    """Test unknown tool name typo correction with fuzzy matching."""
+
+    @pytest.fixture
+    def server(self):
+        return create_server()
+
+    @pytest.fixture
+    def mock_gateway_client(self):
+        with patch('swarm_provenance_mcp.server.gateway_client'):
+            yield
+
+    async def test_close_typo_suggests_correction(self, server, mock_gateway_client):
+        """Close typos should get 'Did you mean' suggestions."""
+        from swarm_provenance_mcp.server import _suggest_tool_name
+        msg = _suggest_tool_name("purchse_stamp")
+        assert "Did you mean" in msg
+        assert "purchase_stamp" in msg
+
+    async def test_multiple_close_matches(self, server, mock_gateway_client):
+        """When multiple tools are close, suggest all of them."""
+        from swarm_provenance_mcp.server import _suggest_tool_name
+        msg = _suggest_tool_name("list_stamp")
+        assert "Did you mean" in msg
+        assert "list_stamps" in msg
+
+    async def test_no_close_match_lists_all(self, server, mock_gateway_client):
+        """Completely wrong name should list all available tools."""
+        from swarm_provenance_mcp.server import _suggest_tool_name
+        msg = _suggest_tool_name("xyzzy_foobar_baz")
+        assert "Available tools:" in msg
+
+    async def test_unknown_tool_error_includes_suggestion(self, server, mock_gateway_client):
+        """Unknown tool via call_tool should include suggestion and retryable: false."""
+        # call_tool_directly doesn't go through create_server's call_tool wrapper,
+        # so test _suggest_tool_name and _format_error directly
+        from swarm_provenance_mcp.server import _suggest_tool_name, _format_error
+        msg = _format_error(_suggest_tool_name("helth_check"), retryable=False)
+        assert "health_check" in msg
+        assert "retryable: false" in msg
+
+
+class TestAdaptiveHealthCheck:
+    """Test the adaptive health_check response with ready flag and recommendations."""
+
+    @pytest.fixture
+    def server(self):
+        return create_server()
+
+    async def test_healthy_with_usable_stamps(self, server):
+        """Healthy gateway + usable stamps → ready: true, _next: upload_data."""
+        with patch('swarm_provenance_mcp.server.gateway_client') as mock_client:
+            mock_client.health_check.return_value = {
+                "status": "healthy",
+                "gateway_url": "http://localhost:8000",
+                "response_time_ms": 10
+            }
+            mock_client.list_stamps.return_value = {
+                "stamps": [{"batchID": TEST_STAMP_ID, "usable": True}],
+                "total_count": 1
+            }
+            result = await call_tool_directly(server, "health_check", {})
+            text = result.content[0].text
+            assert "ready: true" in text
+            assert "_next: upload_data" in text
+
+    async def test_healthy_no_stamps(self, server):
+        """Healthy gateway + no stamps → ready: false, _next: purchase_stamp."""
+        with patch('swarm_provenance_mcp.server.gateway_client') as mock_client:
+            mock_client.health_check.return_value = {
+                "status": "healthy",
+                "gateway_url": "http://localhost:8000",
+                "response_time_ms": 10
+            }
+            mock_client.list_stamps.return_value = {"stamps": [], "total_count": 0}
+            result = await call_tool_directly(server, "health_check", {})
+            text = result.content[0].text
+            assert "ready: false" in text
+            assert "_next: purchase_stamp" in text
+            assert "_recommendations:" in text
+
+    async def test_healthy_no_usable_stamps(self, server):
+        """Healthy gateway + stamps but none usable → ready: false, recommends purchase."""
+        with patch('swarm_provenance_mcp.server.gateway_client') as mock_client:
+            mock_client.health_check.return_value = {
+                "status": "healthy",
+                "gateway_url": "http://localhost:8000",
+                "response_time_ms": 10
+            }
+            mock_client.list_stamps.return_value = {
+                "stamps": [{"batchID": TEST_STAMP_ID, "usable": False}],
+                "total_count": 1
+            }
+            result = await call_tool_directly(server, "health_check", {})
+            text = result.content[0].text
+            assert "ready: false" in text
+            assert "_next: purchase_stamp" in text
+
+    async def test_unhealthy_gateway(self, server):
+        """Unhealthy gateway → ready: false with gateway recommendation."""
+        with patch('swarm_provenance_mcp.server.gateway_client') as mock_client:
+            mock_client.health_check.return_value = {
+                "status": "unhealthy",
+                "gateway_url": "http://localhost:8000",
+                "response_time_ms": 5000
+            }
+            result = await call_tool_directly(server, "health_check", {})
+            text = result.content[0].text
+            assert "ready: false" in text
+            assert "_recommendations:" in text
+
+    async def test_gateway_connection_failure(self, server):
+        """Connection failure → isError with retryable flag."""
+        from requests.exceptions import ConnectionError
+        with patch('swarm_provenance_mcp.server.gateway_client') as mock_client:
+            mock_client.health_check.side_effect = ConnectionError("refused")
+            result = await call_tool_directly(server, "health_check", {})
+            assert result.isError
+            text = result.content[0].text
+            assert "retryable: true" in text
+
+    async def test_response_has_related_tools(self, server):
+        """health_check response should list related tools."""
+        with patch('swarm_provenance_mcp.server.gateway_client') as mock_client:
+            mock_client.health_check.return_value = {
+                "status": "healthy",
+                "gateway_url": "http://localhost:8000",
+                "response_time_ms": 10
+            }
+            mock_client.list_stamps.return_value = {
+                "stamps": [{"batchID": TEST_STAMP_ID, "usable": True}],
+                "total_count": 1
+            }
+            result = await call_tool_directly(server, "health_check", {})
+            text = result.content[0].text
+            assert "_related:" in text
+
+
 class TestToolParameterValidation:
     """Test parameter validation for all tools."""
 


### PR DESCRIPTION
## Summary

- Reworks `health_check` as an **adaptive status tool** — checks gateway connectivity AND stamp availability, returns `ready` boolean, `_recommendations` list, and contextual `_next` tool suggestion (#76)
- Adds **`_next` / `_related` hints** to all 10 tool success responses, guiding agents to the logical next step based on result state (e.g., usable stamp → `_next: upload_data`, no stamps → `_next: purchase_stamp`) (#77)
- Adds **structured error responses** with `retryable` flag and `_next` recovery hint across all handler error paths. Transient errors (429, timeout, connection) marked retryable; permanent errors (validation, unknown tool) marked non-retryable (#78)
- Adds **typo correction** for unknown tool names using Levenshtein distance fuzzy matching

## Test plan

- [x] All 102 local tests pass (7 skipped integration tests)
- [ ] Verify health_check returns `ready: true` and `_next: upload_data` when stamps are available
- [ ] Verify error responses include `retryable:` flag
- [ ] Verify unknown tool names get "Did you mean?" suggestions
- [ ] Docker tests pass in CI

Closes #76, closes #77, closes #78