### PR TITLE
Add chain anchoring infrastructure (#48)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,13 @@ PAYMENT_MODE=free
 # MCP Server Configuration
 MCP_SERVER_NAME=swarm-provenance-mcp
 MCP_SERVER_VERSION=0.1.0
+
+# Chain Anchoring Configuration
+# Enable on-chain provenance via DataProvenance smart contract
+CHAIN_ENABLED=false
+# CHAIN_NAME=base-sepolia
+# PROVENANCE_WALLET_KEY=0x...your_private_key_here...
+# CHAIN_RPC_URL=https://sepolia.base.org
+# CHAIN_CONTRACT=0x9a3c6F47B69211F05891CCb7aD33596290b9fE64
+# CHAIN_EXPLORER_URL=https://sepolia.basescan.org
+# CHAIN_GAS_LIMIT=500000

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,11 +78,24 @@ pytest tests/test_docker.py -v -m docker
 - **MCP Server** (`server.py`): Main server implementing Model Context Protocol with tool handlers
 - **Gateway Client** (`gateway_client.py`): HTTP client for communicating with swarm_connect FastAPI gateway
 - **Configuration** (`config.py`): Pydantic-based settings management with environment variable support
+- **Chain Module** (`chain/`): Optional on-chain provenance anchoring via DataProvenance smart contract
 
 ### Communication Flow
 ```
 AI Agents → MCP Server → Gateway Client → swarm_connect Gateway → Swarm Network
+                       → Chain Client  → Base Sepolia RPC → DataProvenance Contract
 ```
+
+### Chain Module (`chain/`)
+Optional module for on-chain provenance. Requires `pip install -e .[blockchain]`.
+- `chain/__init__.py` — Import guard (`CHAIN_AVAILABLE` flag)
+- `chain/client.py` — High-level facade (anchor, verify, transform, access)
+- `chain/provider.py` — Web3 RPC connection management
+- `chain/wallet.py` — Private key loading and transaction signing
+- `chain/contract.py` — DataProvenance contract wrapper (build_*_tx, read methods)
+- `chain/models.py` — Pydantic models (AnchorResult, ChainProvenanceRecord, etc.)
+- `chain/exceptions.py` — Standalone exception hierarchy (ChainError base)
+- `chain/abi/DataProvenance.json` — Contract ABI
 
 ### Available MCP Tools
 - `purchase_stamp` - Create new postage stamps
@@ -117,6 +130,13 @@ AI Agents → MCP Server → Gateway Client → swarm_connect Gateway → Swarm 
 - `PAYMENT_MODE`: Gateway payment tier — `free` for rate-limited free tier (default: `free`)
 - `MCP_SERVER_NAME`: Server identification (default: `swarm-provenance-mcp`)
 - `MCP_SERVER_VERSION`: Server version (default: `0.1.0`)
+- `CHAIN_ENABLED`: Enable on-chain provenance anchoring (default: `false`)
+- `CHAIN_NAME`: Blockchain network (`base-sepolia` or `base`, default: `base-sepolia`)
+- `PROVENANCE_WALLET_KEY`: Private key for chain transactions (hex, with or without 0x)
+- `CHAIN_RPC_URL`: Custom RPC endpoint (uses chain preset if not set)
+- `CHAIN_CONTRACT`: Custom DataProvenance contract address (uses chain preset if not set)
+- `CHAIN_EXPLORER_URL`: Custom block explorer URL (uses chain preset if not set)
+- `CHAIN_GAS_LIMIT`: Explicit gas limit for chain transactions (skips estimation if set)
 
 ### Settings Management
 The `config.py` module uses Pydantic Settings for type-safe configuration with automatic environment variable loading and validation.

--- a/README.md
+++ b/README.md
@@ -407,20 +407,22 @@ Add to your `claude_desktop_config.json`:
 │                 │    │                 │    │   Gateway       │
 │ • Claude        │    │ • Tool handlers │    │                 │
 │ • Other LLMs    │    │ • Gateway client│    │ • Purchase API  │
-│ • Custom agents │    │ • Error handling│    │ • Status API    │
-└─────────────────┘    └─────────────────┘    │ • Extension API │
-                                              └─────────┬───────┘
-                                                        │
-                                              ┌─────────▼───────┐
-                                              │  Swarm Network  │
-                                              │   (Bee Node)    │
-                                              └─────────────────┘
+│ • Custom agents │    │ • Chain client  │    │ • Status API    │
+└─────────────────┘    │ • Error handling│    │ • Extension API │
+                       └────────┬────────┘    └─────────┬───────┘
+                                │                       │
+                       ┌────────▼────────┐    ┌─────────▼───────┐
+                       │  Base Sepolia   │    │  Swarm Network  │
+                       │  (DataProv.     │    │   (Bee Node)    │
+                       │   Contract)     │    └─────────────────┘
+                       └─────────────────┘
 ```
 
 ### Components
 
 - **MCP Server**: Exposes tools via the Model Context Protocol
 - **Gateway Client**: HTTP client for communicating with swarm_connect
+- **Chain Client** (optional): On-chain provenance via DataProvenance smart contract on Base Sepolia
 - **Configuration**: Environment-based settings management
 - **Error Handling**: Comprehensive error handling and logging
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,10 @@ test = [
     "psutil>=5.9.0",
     "jsonschema>=4.0.0",
 ]
+blockchain = [
+    "web3>=6.0.0",
+    "eth-account>=0.10.0",
+]
 security = [
     "safety>=2.0.0",
     "bandit>=1.7.0",
@@ -61,6 +65,9 @@ swarm-provenance-mcp = "swarm_provenance_mcp.server:main_sync"
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["swarm_provenance_mcp*"]
+
+[tool.setuptools.package-data]
+"swarm_provenance_mcp.chain" = ["abi/*.json"]
 
 [tool.black]
 line-length = 88
@@ -87,6 +94,7 @@ markers = [
     "regression: marks tests as regression tests",
     "smoke: marks tests as smoke tests for quick validation",
     "docker: marks tests requiring a running Docker daemon",
+    "blockchain: marks tests requiring blockchain dependencies (web3, eth-account)",
 ]
 filterwarnings = [
     "ignore::DeprecationWarning:pydantic.*",

--- a/swarm_provenance_mcp/chain/__init__.py
+++ b/swarm_provenance_mcp/chain/__init__.py
@@ -1,0 +1,14 @@
+"""Chain subpackage for blockchain integration with DataProvenance contract."""
+
+try:
+    import eth_account  # noqa: F401
+    import web3  # noqa: F401
+
+    from .client import ChainClient
+
+    CHAIN_AVAILABLE = True
+    __all__ = ["CHAIN_AVAILABLE", "ChainClient"]
+except ImportError:
+    CHAIN_AVAILABLE = False
+    ChainClient = None
+    __all__ = ["CHAIN_AVAILABLE"]

--- a/swarm_provenance_mcp/chain/abi/DataProvenance.json
+++ b/swarm_provenance_mcp/chain/abi/DataProvenance.json
@@ -1,0 +1,851 @@
+[
+  {
+    "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "dataHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "accessor",
+        "type": "address"
+      }
+    ],
+    "name": "DataAccessed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "dataHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "DataOwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "dataHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "dataType",
+        "type": "string"
+      }
+    ],
+    "name": "DataRegistered",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "dataHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "enum DataProvenance.DataStatus",
+        "name": "oldStatus",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "enum DataProvenance.DataStatus",
+        "name": "newStatus",
+        "type": "uint8"
+      }
+    ],
+    "name": "DataStatusChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "originalDataHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "newDataHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "transformation",
+        "type": "string"
+      }
+    ],
+    "name": "DataTransformed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "delegate",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "authorized",
+        "type": "bool"
+      }
+    ],
+    "name": "DelegateAuthorized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "RoleGranted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "RoleRevoked",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "ADMIN_ROLE",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "AUDITOR_ROLE",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MAX_ACCESSORS",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MAX_TRANSFORMATIONS",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "OPERATOR_ROLE",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "authorizedDelegates",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32[]",
+        "name": "_dataHashes",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "batchRecordAccess",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32[]",
+        "name": "_dataHashes",
+        "type": "bytes32[]"
+      },
+      {
+        "internalType": "string[]",
+        "name": "_dataTypes",
+        "type": "string[]"
+      }
+    ],
+    "name": "batchRegisterData",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32[]",
+        "name": "_dataHashes",
+        "type": "bytes32[]"
+      },
+      {
+        "internalType": "enum DataProvenance.DataStatus[]",
+        "name": "_statuses",
+        "type": "uint8[]"
+      }
+    ],
+    "name": "batchSetDataStatus",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "contractAdmin",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "dataRecords",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "dataHash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      },
+      {
+        "internalType": "string",
+        "name": "dataType",
+        "type": "string"
+      },
+      {
+        "internalType": "enum DataProvenance.DataStatus",
+        "name": "status",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_dataHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getDataRecord",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "bytes32",
+            "name": "dataHash",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "address",
+            "name": "owner",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "timestamp",
+            "type": "uint256"
+          },
+          {
+            "internalType": "string",
+            "name": "dataType",
+            "type": "string"
+          },
+          {
+            "internalType": "string[]",
+            "name": "transformations",
+            "type": "string[]"
+          },
+          {
+            "internalType": "address[]",
+            "name": "accessors",
+            "type": "address[]"
+          },
+          {
+            "internalType": "enum DataProvenance.DataStatus",
+            "name": "status",
+            "type": "uint8"
+          }
+        ],
+        "internalType": "struct DataProvenance.DataRecord",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      }
+    ],
+    "name": "getRoleMember",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getRoleMemberCount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_user",
+        "type": "address"
+      }
+    ],
+    "name": "getUserDataRecords",
+    "outputs": [
+      {
+        "internalType": "bytes32[]",
+        "name": "",
+        "type": "bytes32[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_user",
+        "type": "address"
+      }
+    ],
+    "name": "getUserDataRecordsCount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_user",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_offset",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_limit",
+        "type": "uint256"
+      }
+    ],
+    "name": "getUserDataRecordsPaginated",
+    "outputs": [
+      {
+        "internalType": "bytes32[]",
+        "name": "",
+        "type": "bytes32[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "grantRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_dataHash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "_accessor",
+        "type": "address"
+      }
+    ],
+    "name": "hasAddressAccessed",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "hasRole",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_delegate",
+        "type": "address"
+      }
+    ],
+    "name": "isAuthorizedDelegate",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_dataHash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "enum DataProvenance.DataStatus",
+        "name": "_newStatus",
+        "type": "uint8"
+      }
+    ],
+    "name": "operatorSetDataStatus",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_dataHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "recordAccess",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_originalDataHash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_newDataHash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "string",
+        "name": "_transformation",
+        "type": "string"
+      }
+    ],
+    "name": "recordTransformation",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_dataHash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "string",
+        "name": "_dataType",
+        "type": "string"
+      }
+    ],
+    "name": "registerData",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_dataHash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "string",
+        "name": "_dataType",
+        "type": "string"
+      },
+      {
+        "internalType": "address",
+        "name": "_actualOwner",
+        "type": "address"
+      }
+    ],
+    "name": "registerDataFor",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      }
+    ],
+    "name": "renounceRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "revokeRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_dataHash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "enum DataProvenance.DataStatus",
+        "name": "_newStatus",
+        "type": "uint8"
+      }
+    ],
+    "name": "setDataStatus",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_delegate",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_authorized",
+        "type": "bool"
+      }
+    ],
+    "name": "setDelegate",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_dataHash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "_newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferDataOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "userDataRecords",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/swarm_provenance_mcp/chain/client.py
+++ b/swarm_provenance_mcp/chain/client.py
@@ -1,0 +1,744 @@
+"""
+High-level client for on-chain provenance operations.
+
+Provides a facade over ChainProvider, ChainWallet, and DataProvenanceContract
+that mirrors the gateway_client.py pattern: simple method calls that handle
+gas estimation, signing, broadcasting, and receipt parsing.
+
+Requires optional dependencies: pip install -e .[blockchain]
+"""
+
+import logging
+from typing import List, Optional
+
+from .contract import DataStatus
+from .exceptions import (
+    ChainTransactionError,
+    DataAlreadyRegisteredError,
+    DataNotRegisteredError,
+)
+from .models import (
+    AccessResult,
+    AnchorResult,
+    ChainProvenanceRecord,
+    ChainTransformation,
+    ChainWalletInfo,
+    DataStatusEnum,
+    TransformResult,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ChainClient:
+    """High-level client for DataProvenance smart contract operations.
+
+    Wraps provider, wallet, and contract into a single interface for
+    anchoring Swarm hashes on-chain, recording transformations and access,
+    and querying provenance records.
+    """
+
+    def __init__(
+        self,
+        chain: str = "base-sepolia",
+        rpc_url: Optional[str] = None,
+        contract_address: Optional[str] = None,
+        private_key: Optional[str] = None,
+        private_key_env: str = "PROVENANCE_WALLET_KEY",
+        gas_limit_multiplier: float = 1.2,
+        explorer_url: Optional[str] = None,
+        gas_limit: Optional[int] = None,
+    ):
+        """
+        Initialize the chain client.
+
+        Args:
+            chain: Chain name ('base-sepolia' or 'base').
+            rpc_url: Custom RPC URL. If None, uses preset.
+            contract_address: Custom contract address. If None, uses preset.
+            private_key: Wallet private key. If None, reads from env var.
+            private_key_env: Environment variable name for private key.
+            gas_limit_multiplier: Safety multiplier for gas estimates (default 1.2).
+            explorer_url: Custom block explorer URL. If None, uses preset.
+            gas_limit: Explicit gas limit. If set, skips estimation and multiplier.
+
+        Raises:
+            ChainConfigurationError: If dependencies missing or config invalid.
+        """
+        from .provider import ChainProvider
+        from .wallet import ChainWallet
+        from .contract import DataProvenanceContract
+
+        self._provider = ChainProvider(
+            chain=chain,
+            rpc_url=rpc_url,
+            contract_address=contract_address,
+            explorer_url=explorer_url,
+        )
+        self._wallet = ChainWallet(
+            private_key=private_key,
+            private_key_env=private_key_env,
+        )
+        self._contract = DataProvenanceContract(
+            web3=self._provider.web3,
+            contract_address=self._provider.contract_address,
+        )
+        self._gas_limit_multiplier = gas_limit_multiplier
+        self._gas_limit = gas_limit
+
+    @property
+    def address(self) -> str:
+        """Wallet address."""
+        return self._wallet.address
+
+    @property
+    def chain(self) -> str:
+        """Chain name."""
+        return self._provider.chain
+
+    @property
+    def contract_address(self) -> str:
+        """DataProvenance contract address."""
+        return self._provider.contract_address
+
+    # --- Internal helpers ---
+
+    def _send_transaction(self, tx: dict) -> dict:
+        """
+        Estimate gas, sign, broadcast, and wait for receipt.
+
+        Args:
+            tx: Unsigned transaction dict from a build_*_tx method.
+
+        Returns:
+            Transaction receipt dict.
+
+        Raises:
+            ChainTransactionError: If transaction fails.
+        """
+        web3 = self._provider.web3
+
+        try:
+            # Fill in nonce
+            tx["nonce"] = web3.eth.get_transaction_count(self._wallet.address)
+            tx["chainId"] = self._provider.chain_id
+
+            # Set gas limit: explicit value or estimate with multiplier
+            if self._gas_limit is not None:
+                tx["gas"] = self._gas_limit
+                logger.debug("Using explicit gas limit: %d", self._gas_limit)
+            else:
+                estimated_gas = web3.eth.estimate_gas(tx)
+                tx["gas"] = int(estimated_gas * self._gas_limit_multiplier)
+                logger.debug("Estimated gas: %d, limit: %d", estimated_gas, tx["gas"])
+
+            # Sign and send
+            raw_tx = self._wallet.sign_transaction(tx)
+            tx_hash = web3.eth.send_raw_transaction(raw_tx)
+
+            logger.debug("Transaction sent: %s", tx_hash.hex())
+
+            # Wait for receipt
+            receipt = web3.eth.wait_for_transaction_receipt(tx_hash, timeout=120)
+
+            if receipt["status"] != 1:
+                raise ChainTransactionError(
+                    "Transaction reverted (status=0)",
+                    tx_hash=tx_hash.hex(),
+                )
+
+            logger.debug(
+                "Transaction confirmed in block %d, gas used: %d",
+                receipt["blockNumber"],
+                receipt["gasUsed"],
+            )
+
+            return receipt
+
+        except ChainTransactionError:
+            raise
+        except Exception as e:
+            tx_hash_str = None
+            if "tx_hash" in dir():
+                tx_hash_str = tx_hash.hex() if hasattr(tx_hash, "hex") else str(tx_hash)
+            raise ChainTransactionError(
+                f"Transaction failed: {e}",
+                tx_hash=tx_hash_str,
+            ) from e
+
+    def _receipt_to_explorer_url(self, receipt: dict) -> Optional[str]:
+        """Get explorer URL from a transaction receipt."""
+        tx_hash = receipt.get("transactionHash")
+        if tx_hash:
+            return self._provider.get_explorer_tx_url(tx_hash.hex())
+        return None
+
+    # --- Write operations ---
+
+    def anchor(
+        self,
+        swarm_hash: str,
+        data_type: str = "swarm-provenance",
+    ) -> AnchorResult:
+        """
+        Anchor a Swarm hash on-chain by registering it in the DataProvenance contract.
+
+        Args:
+            swarm_hash: Swarm reference hash (64 hex chars).
+            data_type: Data type/category (max 64 chars, default 'swarm-provenance').
+
+        Returns:
+            AnchorResult with transaction details.
+        """
+        logger.debug("Anchor: hash=%s type=%s", swarm_hash, data_type)
+
+        # Pre-check: avoid wasting gas on already-registered hashes
+        try:
+            record = self.get(swarm_hash)
+            raise DataAlreadyRegisteredError(
+                f"Data hash {swarm_hash} is already registered on-chain",
+                data_hash=swarm_hash,
+                owner=record.owner,
+                timestamp=record.timestamp,
+                data_type=record.data_type,
+            )
+        except DataNotRegisteredError:
+            pass  # Not registered -- proceed with anchoring
+
+        tx = self._contract.build_register_data_tx(
+            data_hash=swarm_hash,
+            data_type=data_type,
+            sender=self._wallet.address,
+        )
+        receipt = self._send_transaction(tx)
+
+        return AnchorResult(
+            tx_hash=receipt["transactionHash"].hex(),
+            block_number=receipt["blockNumber"],
+            gas_used=receipt["gasUsed"],
+            explorer_url=self._receipt_to_explorer_url(receipt),
+            swarm_hash=swarm_hash,
+            data_type=data_type,
+            owner=self._wallet.address,
+        )
+
+    def anchor_for(
+        self,
+        swarm_hash: str,
+        owner: str,
+        data_type: str = "swarm-provenance",
+    ) -> AnchorResult:
+        """
+        Anchor a Swarm hash on behalf of another owner.
+
+        Caller must be an authorized delegate of the owner.
+
+        Args:
+            swarm_hash: Swarm reference hash.
+            owner: Address of the actual data owner.
+            data_type: Data type/category.
+
+        Returns:
+            AnchorResult with transaction details.
+        """
+        logger.debug("Anchor for: hash=%s owner=%s", swarm_hash, owner)
+
+        # Pre-check: avoid wasting gas on already-registered hashes
+        try:
+            record = self.get(swarm_hash)
+            raise DataAlreadyRegisteredError(
+                f"Data hash {swarm_hash} is already registered on-chain",
+                data_hash=swarm_hash,
+                owner=record.owner,
+                timestamp=record.timestamp,
+                data_type=record.data_type,
+            )
+        except DataNotRegisteredError:
+            pass  # Not registered -- proceed with anchoring
+
+        tx = self._contract.build_register_data_for_tx(
+            data_hash=swarm_hash,
+            data_type=data_type,
+            actual_owner=owner,
+            sender=self._wallet.address,
+        )
+        receipt = self._send_transaction(tx)
+
+        return AnchorResult(
+            tx_hash=receipt["transactionHash"].hex(),
+            block_number=receipt["blockNumber"],
+            gas_used=receipt["gasUsed"],
+            explorer_url=self._receipt_to_explorer_url(receipt),
+            swarm_hash=swarm_hash,
+            data_type=data_type,
+            owner=owner,
+        )
+
+    def batch_anchor(
+        self,
+        swarm_hashes: List[str],
+        data_types: List[str],
+    ) -> AnchorResult:
+        """
+        Anchor multiple Swarm hashes in a single transaction.
+
+        Args:
+            swarm_hashes: List of Swarm reference hashes.
+            data_types: List of data type strings (same length).
+
+        Returns:
+            AnchorResult for the batch transaction (swarm_hash is first hash).
+        """
+        logger.debug("Batch anchor: count=%d", len(swarm_hashes))
+
+        tx = self._contract.build_batch_register_data_tx(
+            data_hashes=swarm_hashes,
+            data_types=data_types,
+            sender=self._wallet.address,
+        )
+        receipt = self._send_transaction(tx)
+
+        return AnchorResult(
+            tx_hash=receipt["transactionHash"].hex(),
+            block_number=receipt["blockNumber"],
+            gas_used=receipt["gasUsed"],
+            explorer_url=self._receipt_to_explorer_url(receipt),
+            swarm_hash=swarm_hashes[0] if swarm_hashes else "",
+            data_type=data_types[0] if data_types else "",
+            owner=self._wallet.address,
+        )
+
+    def transform(
+        self,
+        original_hash: str,
+        new_hash: str,
+        description: str,
+    ) -> TransformResult:
+        """
+        Record a data transformation on-chain.
+
+        Args:
+            original_hash: Hash of the original data.
+            new_hash: Hash of the transformed data.
+            description: Transformation description (max 256 chars).
+
+        Returns:
+            TransformResult with transaction details.
+        """
+        logger.debug(
+            "Transform: original=%s new=%s desc=%s",
+            original_hash,
+            new_hash,
+            description,
+        )
+
+        tx = self._contract.build_record_transformation_tx(
+            original_hash=original_hash,
+            new_hash=new_hash,
+            description=description,
+            sender=self._wallet.address,
+        )
+        receipt = self._send_transaction(tx)
+
+        return TransformResult(
+            tx_hash=receipt["transactionHash"].hex(),
+            block_number=receipt["blockNumber"],
+            gas_used=receipt["gasUsed"],
+            explorer_url=self._receipt_to_explorer_url(receipt),
+            original_hash=original_hash,
+            new_hash=new_hash,
+            description=description,
+        )
+
+    def access(
+        self,
+        swarm_hash: str,
+    ) -> AccessResult:
+        """
+        Record that data was accessed.
+
+        Args:
+            swarm_hash: Hash of the accessed data.
+
+        Returns:
+            AccessResult with transaction details.
+        """
+        logger.debug("Record access: hash=%s", swarm_hash)
+
+        tx = self._contract.build_record_access_tx(
+            data_hash=swarm_hash,
+            sender=self._wallet.address,
+        )
+        receipt = self._send_transaction(tx)
+
+        return AccessResult(
+            tx_hash=receipt["transactionHash"].hex(),
+            block_number=receipt["blockNumber"],
+            gas_used=receipt["gasUsed"],
+            explorer_url=self._receipt_to_explorer_url(receipt),
+            swarm_hash=swarm_hash,
+            accessor=self._wallet.address,
+        )
+
+    def batch_access(
+        self,
+        swarm_hashes: List[str],
+    ) -> AccessResult:
+        """
+        Record access to multiple data hashes in a single transaction.
+
+        Args:
+            swarm_hashes: List of accessed data hashes.
+
+        Returns:
+            AccessResult for the batch transaction.
+        """
+        logger.debug("Batch access: count=%d", len(swarm_hashes))
+
+        tx = self._contract.build_batch_record_access_tx(
+            data_hashes=swarm_hashes,
+            sender=self._wallet.address,
+        )
+        receipt = self._send_transaction(tx)
+
+        return AccessResult(
+            tx_hash=receipt["transactionHash"].hex(),
+            block_number=receipt["blockNumber"],
+            gas_used=receipt["gasUsed"],
+            explorer_url=self._receipt_to_explorer_url(receipt),
+            swarm_hash=swarm_hashes[0] if swarm_hashes else "",
+            accessor=self._wallet.address,
+        )
+
+    def set_status(
+        self,
+        swarm_hash: str,
+        status: int,
+    ) -> AnchorResult:
+        """
+        Set the status of a registered data hash.
+
+        Args:
+            swarm_hash: Hash of the data.
+            status: New status (0=ACTIVE, 1=RESTRICTED, 2=DELETED).
+
+        Returns:
+            AnchorResult with transaction details.
+        """
+        logger.debug(
+            "Set status: hash=%s status=%s", swarm_hash, DataStatus(status).name
+        )
+
+        tx = self._contract.build_set_data_status_tx(
+            data_hash=swarm_hash,
+            status=status,
+            sender=self._wallet.address,
+        )
+        receipt = self._send_transaction(tx)
+
+        return AnchorResult(
+            tx_hash=receipt["transactionHash"].hex(),
+            block_number=receipt["blockNumber"],
+            gas_used=receipt["gasUsed"],
+            explorer_url=self._receipt_to_explorer_url(receipt),
+            swarm_hash=swarm_hash,
+            data_type="",
+            owner=self._wallet.address,
+        )
+
+    def batch_set_status(
+        self,
+        swarm_hashes: List[str],
+        statuses: List[int],
+    ) -> AnchorResult:
+        """
+        Set the status of multiple registered data hashes in a single transaction.
+
+        Args:
+            swarm_hashes: List of data hashes.
+            statuses: List of new statuses (0=ACTIVE, 1=RESTRICTED, 2=DELETED).
+
+        Returns:
+            AnchorResult with transaction details.
+        """
+        logger.debug("Batch set status: count=%d", len(swarm_hashes))
+
+        tx = self._contract.build_batch_set_data_status_tx(
+            data_hashes=swarm_hashes,
+            statuses=statuses,
+            sender=self._wallet.address,
+        )
+        receipt = self._send_transaction(tx)
+
+        return AnchorResult(
+            tx_hash=receipt["transactionHash"].hex(),
+            block_number=receipt["blockNumber"],
+            gas_used=receipt["gasUsed"],
+            explorer_url=self._receipt_to_explorer_url(receipt),
+            swarm_hash=swarm_hashes[0] if swarm_hashes else "",
+            data_type="",
+            owner=self._wallet.address,
+        )
+
+    def transfer_ownership(
+        self,
+        swarm_hash: str,
+        new_owner: str,
+    ) -> AnchorResult:
+        """
+        Transfer ownership of a data hash to a new address.
+
+        Args:
+            swarm_hash: Hash of the data.
+            new_owner: Address of the new owner.
+
+        Returns:
+            AnchorResult with transaction details.
+        """
+        logger.debug("Transfer ownership: hash=%s new_owner=%s", swarm_hash, new_owner)
+
+        tx = self._contract.build_transfer_ownership_tx(
+            data_hash=swarm_hash,
+            new_owner=new_owner,
+            sender=self._wallet.address,
+        )
+        receipt = self._send_transaction(tx)
+
+        return AnchorResult(
+            tx_hash=receipt["transactionHash"].hex(),
+            block_number=receipt["blockNumber"],
+            gas_used=receipt["gasUsed"],
+            explorer_url=self._receipt_to_explorer_url(receipt),
+            swarm_hash=swarm_hash,
+            data_type="",
+            owner=new_owner,
+        )
+
+    def set_delegate(
+        self,
+        delegate: str,
+        authorized: bool = True,
+    ) -> AnchorResult:
+        """
+        Authorize or revoke a delegate address.
+
+        Args:
+            delegate: Address to authorize/revoke.
+            authorized: True to authorize, False to revoke.
+
+        Returns:
+            AnchorResult with transaction details.
+        """
+        action = "Authorize" if authorized else "Revoke"
+        logger.debug("%s delegate: %s", action, delegate)
+
+        tx = self._contract.build_set_delegate_tx(
+            delegate=delegate,
+            authorized=authorized,
+            sender=self._wallet.address,
+        )
+        receipt = self._send_transaction(tx)
+
+        return AnchorResult(
+            tx_hash=receipt["transactionHash"].hex(),
+            block_number=receipt["blockNumber"],
+            gas_used=receipt["gasUsed"],
+            explorer_url=self._receipt_to_explorer_url(receipt),
+            swarm_hash="",
+            data_type="",
+            owner=self._wallet.address,
+        )
+
+    # --- Read operations ---
+
+    def get(
+        self,
+        swarm_hash: str,
+    ) -> ChainProvenanceRecord:
+        """
+        Get the on-chain provenance record for a Swarm hash.
+
+        Args:
+            swarm_hash: Swarm reference hash.
+
+        Returns:
+            ChainProvenanceRecord with full provenance data.
+
+        Raises:
+            DataNotRegisteredError: If hash is not registered on-chain.
+        """
+        logger.debug("Get record: hash=%s", swarm_hash)
+
+        record = self._contract.get_data_record(swarm_hash)
+
+        # record is a tuple: (dataHash, owner, timestamp, dataType,
+        #                      transformations, accessors, status)
+        (
+            data_hash_bytes,
+            owner,
+            timestamp,
+            data_type,
+            transformations,
+            accessors,
+            status,
+        ) = record
+
+        # Check if data is registered (owner is zero address if not)
+        zero_address = "0x" + "0" * 40
+        if owner == zero_address:
+            raise DataNotRegisteredError(
+                f"Data hash {swarm_hash} is not registered on-chain",
+                data_hash=swarm_hash,
+            )
+
+        # Parse transformations -- contract returns string[] (description only)
+        chain_transformations = []
+        for t in transformations:
+            chain_transformations.append(
+                ChainTransformation(
+                    description=str(t),
+                )
+            )
+
+        logger.debug(
+            "Record: owner=%s type=%s status=%s accessors=%d",
+            owner,
+            data_type,
+            DataStatus(status).name,
+            len(accessors),
+        )
+
+        return ChainProvenanceRecord(
+            data_hash=(
+                data_hash_bytes.hex()
+                if isinstance(data_hash_bytes, bytes)
+                else str(data_hash_bytes)
+            ),
+            owner=owner,
+            timestamp=timestamp,
+            data_type=data_type,
+            status=DataStatusEnum(status),
+            accessors=list(accessors),
+            transformations=chain_transformations,
+        )
+
+    def verify(
+        self,
+        swarm_hash: str,
+    ) -> bool:
+        """
+        Verify that a Swarm hash is registered on-chain.
+
+        Args:
+            swarm_hash: Swarm reference hash.
+
+        Returns:
+            True if registered, False if not.
+        """
+        try:
+            self.get(swarm_hash)
+            return True
+        except DataNotRegisteredError:
+            return False
+
+    def balance(self) -> ChainWalletInfo:
+        """
+        Get wallet balance and chain info.
+
+        Returns:
+            ChainWalletInfo with balance and chain details.
+        """
+        logger.debug("Balance check")
+
+        balance_wei = self._wallet.get_balance(self._provider.web3)
+        balance_eth = self._wallet.get_balance_eth(self._provider.web3)
+
+        logger.debug("Address: %s Balance: %s ETH", self._wallet.address, balance_eth)
+
+        return ChainWalletInfo(
+            address=self._wallet.address,
+            balance_wei=balance_wei,
+            balance_eth=balance_eth,
+            chain=self._provider.chain,
+            contract_address=self._provider.contract_address,
+        )
+
+    def health_check(self) -> bool:
+        """
+        Check if the chain provider is connected and healthy.
+
+        Returns:
+            True if healthy.
+
+        Raises:
+            ChainConnectionError: If health check fails.
+        """
+        logger.debug(
+            "Chain health check: chain=%s rpc=%s",
+            self._provider.chain,
+            self._provider.rpc_url,
+        )
+
+        result = self._provider.health_check()
+
+        logger.debug("Connected, block: %d", self._provider.get_block_number())
+
+        return result
+
+    def get_provenance_chain(
+        self,
+        swarm_hash: str,
+        max_depth: Optional[int] = None,
+    ) -> List[ChainProvenanceRecord]:
+        """
+        Get the provenance chain for a data hash.
+
+        Retrieves the record for the given hash. If transformations have
+        new_data_hash links, follows them to build a lineage chain.
+
+        Note: The current contract returns transformation descriptions only
+        (no new_data_hash links), so the chain will typically contain just
+        the queried record. Supply hashes directly to follow known lineages.
+
+        Args:
+            swarm_hash: Starting Swarm reference hash.
+            max_depth: Maximum traversal depth. None means no limit (capped at 50).
+
+        Returns:
+            List of ChainProvenanceRecord forming the provenance chain,
+            starting with the given hash.
+        """
+        logger.debug(
+            "Get provenance chain: hash=%s max_depth=%s", swarm_hash, max_depth
+        )
+
+        effective_max = max_depth if max_depth is not None else 50
+
+        chain = []
+        visited = set()
+        to_visit = [(swarm_hash, 0)]
+
+        while to_visit:
+            current_hash, current_depth = to_visit.pop(0)
+            if current_hash in visited:
+                continue
+            if current_depth > effective_max:
+                logger.debug("Depth limit reached at %d", current_depth)
+                continue
+            visited.add(current_hash)
+
+            try:
+                record = self.get(current_hash)
+                chain.append(record)
+
+                # Follow transformation links if new_data_hash is available
+                for t in record.transformations:
+                    if t.new_data_hash and t.new_data_hash not in visited:
+                        to_visit.append((t.new_data_hash, current_depth + 1))
+            except DataNotRegisteredError:
+                logger.debug("Hash %s not registered, skipping", current_hash)
+                continue
+
+        logger.debug("Chain length: %d", len(chain))
+
+        return chain

--- a/swarm_provenance_mcp/chain/contract.py
+++ b/swarm_provenance_mcp/chain/contract.py
@@ -1,0 +1,590 @@
+"""
+DataProvenance smart contract wrapper.
+
+Provides typed Python methods for all DataProvenance contract functions.
+Build methods return transaction dicts; read methods call directly.
+
+Requires optional dependencies: pip install -e .[blockchain]
+"""
+
+import json
+from enum import IntEnum
+from pathlib import Path
+from typing import List, Tuple
+
+from .exceptions import ChainConfigurationError, ChainValidationError
+
+# --- Constants ---
+# Client-side validation limits (not enforced on-chain — Solidity strings are
+# dynamically sized, so these are reasonable guard rails to prevent wasted gas).
+MAX_DATA_TYPE_LENGTH = 64
+MAX_TRANSFORMATION_LENGTH = 256
+
+# Client-side batch limits. The contract does not enforce per-call batch sizes
+# but larger batches risk exceeding the block gas limit.
+MAX_BATCH_REGISTER = 50
+MAX_BATCH_ACCESS = 100
+
+# Note: the contract also defines on-chain constants MAX_TRANSFORMATIONS (100)
+# and MAX_ACCESSORS readable via contract.functions.MAX_TRANSFORMATIONS().call().
+# These limit how many transformations/accessors can be stored per data record.
+
+
+class DataStatus(IntEnum):
+    """On-chain data status values matching the contract enum."""
+
+    ACTIVE = 0
+    RESTRICTED = 1
+    DELETED = 2
+
+
+# --- Validation helpers ---
+
+
+def _normalize_hash(data_hash: str) -> bytes:
+    """
+    Normalize a hex hash string to bytes32.
+
+    Accepts 64-char hex (with or without 0x prefix) or a raw 32-byte Swarm hash.
+
+    Args:
+        data_hash: Hex string (e.g., '0xabcd...' or 'abcd...').
+
+    Returns:
+        32-byte value suitable for bytes32 contract parameter.
+
+    Raises:
+        ChainValidationError: If hash format is invalid.
+    """
+    if isinstance(data_hash, bytes):
+        if len(data_hash) != 32:
+            raise ChainValidationError(
+                f"Hash must be exactly 32 bytes, got {len(data_hash)}"
+            )
+        return data_hash
+
+    h = data_hash.strip()
+    if h.startswith("0x"):
+        h = h[2:]
+
+    if len(h) != 64:
+        raise ChainValidationError(
+            f"Hash must be 64 hex characters (32 bytes), got {len(h)} characters"
+        )
+
+    try:
+        return bytes.fromhex(h)
+    except ValueError as e:
+        raise ChainValidationError(f"Invalid hex in hash: {e}") from e
+
+
+def _validate_data_type(data_type: str) -> str:
+    """
+    Validate data type string length.
+
+    Args:
+        data_type: Data type/category string.
+
+    Returns:
+        The validated data type string.
+
+    Raises:
+        ChainValidationError: If string exceeds MAX_DATA_TYPE_LENGTH.
+    """
+    if len(data_type) > MAX_DATA_TYPE_LENGTH:
+        raise ChainValidationError(
+            f"data_type exceeds maximum length of {MAX_DATA_TYPE_LENGTH} characters "
+            f"(got {len(data_type)})"
+        )
+    return data_type
+
+
+def _validate_transformation(description: str) -> str:
+    """
+    Validate transformation description string length.
+
+    Args:
+        description: Transformation description string.
+
+    Returns:
+        The validated description string.
+
+    Raises:
+        ChainValidationError: If string exceeds MAX_TRANSFORMATION_LENGTH.
+    """
+    if len(description) > MAX_TRANSFORMATION_LENGTH:
+        raise ChainValidationError(
+            f"transformation description exceeds maximum length of "
+            f"{MAX_TRANSFORMATION_LENGTH} characters (got {len(description)})"
+        )
+    return description
+
+
+def _load_abi() -> list:
+    """
+    Load the DataProvenance contract ABI from the bundled JSON file.
+
+    Returns:
+        Parsed ABI as a list of dicts.
+
+    Raises:
+        ChainConfigurationError: If ABI file cannot be loaded.
+    """
+    abi_path = Path(__file__).parent / "abi" / "DataProvenance.json"
+    try:
+        with open(abi_path, "r") as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError) as e:
+        raise ChainConfigurationError(
+            f"Failed to load DataProvenance ABI from {abi_path}: {e}"
+        ) from e
+
+
+class DataProvenanceContract:
+    """Wrapper around the DataProvenance smart contract.
+
+    Provides build_*_tx() methods that return unsigned transaction dicts
+    and read methods that call the contract directly.
+    """
+
+    def __init__(self, web3, contract_address: str):
+        """
+        Initialize the contract wrapper.
+
+        Args:
+            web3: Web3 instance connected to the target chain.
+            contract_address: Deployed DataProvenance contract address.
+
+        Raises:
+            ChainConfigurationError: If ABI loading or contract init fails.
+        """
+        self._web3 = web3
+        self._address = web3.to_checksum_address(contract_address)
+        self._abi = _load_abi()
+        self._contract = web3.eth.contract(
+            address=self._address,
+            abi=self._abi,
+        )
+
+    @property
+    def address(self) -> str:
+        """Contract address."""
+        return self._address
+
+    # --- Build transaction methods (return tx dicts) ---
+
+    def build_register_data_tx(
+        self,
+        data_hash: str,
+        data_type: str,
+        sender: str,
+    ) -> dict:
+        """
+        Build transaction to register a data hash on-chain.
+
+        Args:
+            data_hash: 64-char hex hash of the data (Swarm reference).
+            data_type: Category/type string (max 64 chars).
+            sender: Address of the transaction sender.
+
+        Returns:
+            Unsigned transaction dict.
+        """
+        hash_bytes = _normalize_hash(data_hash)
+        _validate_data_type(data_type)
+        return self._contract.functions.registerData(
+            hash_bytes, data_type
+        ).build_transaction(
+            {
+                "from": self._web3.to_checksum_address(sender),
+            }
+        )
+
+    def build_register_data_for_tx(
+        self,
+        data_hash: str,
+        data_type: str,
+        actual_owner: str,
+        sender: str,
+    ) -> dict:
+        """
+        Build transaction to register data on behalf of another owner.
+
+        The sender must be an authorized delegate of the actual owner.
+
+        Args:
+            data_hash: 64-char hex hash of the data.
+            data_type: Category/type string (max 64 chars).
+            actual_owner: Address of the actual data owner.
+            sender: Address of the delegate sending the transaction.
+
+        Returns:
+            Unsigned transaction dict.
+        """
+        hash_bytes = _normalize_hash(data_hash)
+        _validate_data_type(data_type)
+        return self._contract.functions.registerDataFor(
+            hash_bytes,
+            data_type,
+            self._web3.to_checksum_address(actual_owner),
+        ).build_transaction(
+            {
+                "from": self._web3.to_checksum_address(sender),
+            }
+        )
+
+    def build_batch_register_data_tx(
+        self,
+        data_hashes: List[str],
+        data_types: List[str],
+        sender: str,
+    ) -> dict:
+        """
+        Build transaction to register multiple data hashes in one call.
+
+        Args:
+            data_hashes: List of 64-char hex hashes.
+            data_types: List of data type strings (same length as hashes).
+            sender: Address of the transaction sender.
+
+        Returns:
+            Unsigned transaction dict.
+
+        Raises:
+            ChainValidationError: If arrays have different lengths or exceed batch limit.
+        """
+        if len(data_hashes) != len(data_types):
+            raise ChainValidationError(
+                f"data_hashes ({len(data_hashes)}) and data_types ({len(data_types)}) "
+                "must have the same length"
+            )
+        if len(data_hashes) > MAX_BATCH_REGISTER:
+            raise ChainValidationError(
+                f"Batch size {len(data_hashes)} exceeds maximum of {MAX_BATCH_REGISTER}"
+            )
+
+        hash_bytes_list = [_normalize_hash(h) for h in data_hashes]
+        for dt in data_types:
+            _validate_data_type(dt)
+
+        return self._contract.functions.batchRegisterData(
+            hash_bytes_list, data_types
+        ).build_transaction(
+            {
+                "from": self._web3.to_checksum_address(sender),
+            }
+        )
+
+    def build_record_transformation_tx(
+        self,
+        original_hash: str,
+        new_hash: str,
+        description: str,
+        sender: str,
+    ) -> dict:
+        """
+        Build transaction to record a data transformation.
+
+        Args:
+            original_hash: Hash of the original data.
+            new_hash: Hash of the transformed data.
+            description: Description of the transformation (max 256 chars).
+            sender: Address of the transaction sender.
+
+        Returns:
+            Unsigned transaction dict.
+        """
+        orig_bytes = _normalize_hash(original_hash)
+        new_bytes = _normalize_hash(new_hash)
+        _validate_transformation(description)
+        return self._contract.functions.recordTransformation(
+            orig_bytes, new_bytes, description
+        ).build_transaction(
+            {
+                "from": self._web3.to_checksum_address(sender),
+            }
+        )
+
+    def build_record_access_tx(
+        self,
+        data_hash: str,
+        sender: str,
+    ) -> dict:
+        """
+        Build transaction to record that data was accessed.
+
+        Args:
+            data_hash: Hash of the accessed data.
+            sender: Address of the accessor.
+
+        Returns:
+            Unsigned transaction dict.
+        """
+        hash_bytes = _normalize_hash(data_hash)
+        return self._contract.functions.recordAccess(hash_bytes).build_transaction(
+            {
+                "from": self._web3.to_checksum_address(sender),
+            }
+        )
+
+    def build_batch_record_access_tx(
+        self,
+        data_hashes: List[str],
+        sender: str,
+    ) -> dict:
+        """
+        Build transaction to record access to multiple data hashes.
+
+        Args:
+            data_hashes: List of data hashes accessed.
+            sender: Address of the accessor.
+
+        Returns:
+            Unsigned transaction dict.
+
+        Raises:
+            ChainValidationError: If batch size exceeds limit.
+        """
+        if len(data_hashes) > MAX_BATCH_ACCESS:
+            raise ChainValidationError(
+                f"Batch size {len(data_hashes)} exceeds maximum of {MAX_BATCH_ACCESS}"
+            )
+        hash_bytes_list = [_normalize_hash(h) for h in data_hashes]
+        return self._contract.functions.batchRecordAccess(
+            hash_bytes_list
+        ).build_transaction(
+            {
+                "from": self._web3.to_checksum_address(sender),
+            }
+        )
+
+    def build_set_data_status_tx(
+        self,
+        data_hash: str,
+        status: int,
+        sender: str,
+    ) -> dict:
+        """
+        Build transaction to change the status of registered data.
+
+        Args:
+            data_hash: Hash of the data.
+            status: New status (0=ACTIVE, 1=RESTRICTED, 2=DELETED).
+            sender: Address of the data owner.
+
+        Returns:
+            Unsigned transaction dict.
+        """
+        hash_bytes = _normalize_hash(data_hash)
+        return self._contract.functions.setDataStatus(
+            hash_bytes, status
+        ).build_transaction(
+            {
+                "from": self._web3.to_checksum_address(sender),
+            }
+        )
+
+    def build_batch_set_data_status_tx(
+        self,
+        data_hashes: List[str],
+        statuses: List[int],
+        sender: str,
+    ) -> dict:
+        """
+        Build transaction to change the status of multiple data hashes.
+
+        Args:
+            data_hashes: List of data hashes.
+            statuses: List of new statuses (0=ACTIVE, 1=RESTRICTED, 2=DELETED).
+            sender: Address of the data owner.
+
+        Returns:
+            Unsigned transaction dict.
+
+        Raises:
+            ChainValidationError: If arrays have different lengths or exceed batch limit.
+        """
+        if len(data_hashes) != len(statuses):
+            raise ChainValidationError(
+                f"data_hashes ({len(data_hashes)}) and statuses ({len(statuses)}) "
+                "must have the same length"
+            )
+        if len(data_hashes) > MAX_BATCH_REGISTER:
+            raise ChainValidationError(
+                f"Batch size {len(data_hashes)} exceeds maximum of {MAX_BATCH_REGISTER}"
+            )
+        hash_bytes_list = [_normalize_hash(h) for h in data_hashes]
+        return self._contract.functions.batchSetDataStatus(
+            hash_bytes_list, statuses
+        ).build_transaction(
+            {
+                "from": self._web3.to_checksum_address(sender),
+            }
+        )
+
+    def build_transfer_ownership_tx(
+        self,
+        data_hash: str,
+        new_owner: str,
+        sender: str,
+    ) -> dict:
+        """
+        Build transaction to transfer data ownership.
+
+        Args:
+            data_hash: Hash of the data.
+            new_owner: Address of the new owner.
+            sender: Address of the current owner.
+
+        Returns:
+            Unsigned transaction dict.
+        """
+        hash_bytes = _normalize_hash(data_hash)
+        return self._contract.functions.transferDataOwnership(
+            hash_bytes,
+            self._web3.to_checksum_address(new_owner),
+        ).build_transaction(
+            {
+                "from": self._web3.to_checksum_address(sender),
+            }
+        )
+
+    def build_set_delegate_tx(
+        self,
+        delegate: str,
+        authorized: bool,
+        sender: str,
+    ) -> dict:
+        """
+        Build transaction to authorize or revoke a delegate.
+
+        Args:
+            delegate: Address of the delegate.
+            authorized: True to authorize, False to revoke.
+            sender: Address of the data owner.
+
+        Returns:
+            Unsigned transaction dict.
+        """
+        return self._contract.functions.setDelegate(
+            self._web3.to_checksum_address(delegate),
+            authorized,
+        ).build_transaction(
+            {
+                "from": self._web3.to_checksum_address(sender),
+            }
+        )
+
+    # --- Read methods (direct contract calls) ---
+
+    def get_data_record(self, data_hash: str) -> Tuple:
+        """
+        Get the full on-chain record for a data hash.
+
+        Args:
+            data_hash: 64-char hex hash.
+
+        Returns:
+            Tuple of (dataHash, owner, timestamp, dataType,
+                       transformations, accessors, status).
+        """
+        hash_bytes = _normalize_hash(data_hash)
+        return self._contract.functions.getDataRecord(hash_bytes).call()
+
+    def get_user_data_records(self, user: str) -> List[bytes]:
+        """
+        Get all data hashes registered by a user.
+
+        Args:
+            user: Ethereum address of the user.
+
+        Returns:
+            List of bytes32 data hashes.
+        """
+        return self._contract.functions.getUserDataRecords(
+            self._web3.to_checksum_address(user)
+        ).call()
+
+    def get_user_data_records_count(self, user: str) -> int:
+        """
+        Get the number of data records for a user.
+
+        Args:
+            user: Ethereum address of the user.
+
+        Returns:
+            Count of registered data records.
+        """
+        return self._contract.functions.getUserDataRecordsCount(
+            self._web3.to_checksum_address(user)
+        ).call()
+
+    def get_user_data_records_paginated(
+        self,
+        user: str,
+        offset: int,
+        limit: int,
+    ) -> List[bytes]:
+        """
+        Get a paginated slice of a user's data records.
+
+        Args:
+            user: Ethereum address of the user.
+            offset: Starting index.
+            limit: Maximum number of records to return.
+
+        Returns:
+            List of bytes32 data hashes.
+        """
+        return self._contract.functions.getUserDataRecordsPaginated(
+            self._web3.to_checksum_address(user),
+            offset,
+            limit,
+        ).call()
+
+    def has_address_accessed(self, data_hash: str, accessor: str) -> bool:
+        """
+        Check if an address has accessed a data hash.
+
+        Args:
+            data_hash: 64-char hex hash.
+            accessor: Ethereum address to check.
+
+        Returns:
+            True if the address has accessed the data.
+        """
+        hash_bytes = _normalize_hash(data_hash)
+        return self._contract.functions.hasAddressAccessed(
+            hash_bytes,
+            self._web3.to_checksum_address(accessor),
+        ).call()
+
+    def is_authorized_delegate(self, owner: str, delegate: str) -> bool:
+        """
+        Check if an address is an authorized delegate for an owner.
+
+        Args:
+            owner: Data owner address.
+            delegate: Potential delegate address.
+
+        Returns:
+            True if delegate is authorized.
+        """
+        return self._contract.functions.isAuthorizedDelegate(
+            self._web3.to_checksum_address(owner),
+            self._web3.to_checksum_address(delegate),
+        ).call()
+
+    # --- Gas estimation ---
+
+    def estimate_gas(self, tx: dict) -> int:
+        """
+        Estimate gas for a transaction.
+
+        Args:
+            tx: Transaction dict (from a build_*_tx method).
+
+        Returns:
+            Estimated gas units.
+        """
+        return self._web3.eth.estimate_gas(tx)

--- a/swarm_provenance_mcp/chain/exceptions.py
+++ b/swarm_provenance_mcp/chain/exceptions.py
@@ -1,0 +1,65 @@
+"""Custom exceptions for blockchain-related operations.
+
+Standalone exception hierarchy for the chain module. These do not inherit
+from any MCP-specific base class, keeping the chain module self-contained.
+"""
+
+
+class ChainError(Exception):
+    """Base exception for blockchain-related errors."""
+
+    pass
+
+
+class ChainConfigurationError(ChainError):
+    """Missing dependencies, invalid config, or missing wallet key."""
+
+    pass
+
+
+class ChainConnectionError(ChainError):
+    """Failed to connect to RPC endpoint."""
+
+    def __init__(self, message: str, rpc_url: str = None):
+        super().__init__(message)
+        self.rpc_url = rpc_url
+
+
+class ChainTransactionError(ChainError):
+    """Transaction reverted, ran out of gas, or otherwise failed."""
+
+    def __init__(self, message: str, tx_hash: str = None):
+        super().__init__(message)
+        self.tx_hash = tx_hash
+
+
+class ChainValidationError(ChainError):
+    """Input validation failed (hash format, string lengths, batch limits)."""
+
+    pass
+
+
+class DataNotRegisteredError(ChainError):
+    """Data hash not found on-chain."""
+
+    def __init__(self, message: str, data_hash: str = None):
+        super().__init__(message)
+        self.data_hash = data_hash
+
+
+class DataAlreadyRegisteredError(ChainError):
+    """Data hash is already registered on-chain."""
+
+    def __init__(
+        self,
+        message: str,
+        data_hash: str = None,
+        owner: str = None,
+        timestamp: int = None,
+        data_type: str = None,
+    ):
+        super().__init__(message)
+        self.data_hash = data_hash
+        self.owner = owner
+        self.timestamp = timestamp
+        self.data_type = data_type

--- a/swarm_provenance_mcp/chain/models.py
+++ b/swarm_provenance_mcp/chain/models.py
@@ -1,0 +1,95 @@
+"""Pydantic models for chain/blockchain operations.
+
+Kept in the chain module (not shared models.py) to maintain a clean
+optional dependency boundary — these models are only used when
+blockchain features are enabled.
+"""
+
+from enum import IntEnum
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class DataStatusEnum(IntEnum):
+    """On-chain data status values."""
+
+    ACTIVE = 0
+    RESTRICTED = 1
+    DELETED = 2
+
+
+class ChainTransformation(BaseModel):
+    """A transformation recorded on-chain."""
+
+    description: str = Field(description="Description of the transformation")
+    new_data_hash: Optional[str] = Field(
+        default=None, description="Hash of the transformed data (if available)"
+    )
+
+
+class ChainProvenanceRecord(BaseModel):
+    """On-chain provenance record for a data hash."""
+
+    data_hash: str = Field(description="Swarm reference hash (bytes32 hex)")
+    owner: str = Field(description="Ethereum address of data owner")
+    timestamp: int = Field(description="Unix timestamp when registered")
+    data_type: str = Field(description="Type/category of the data")
+    status: DataStatusEnum = Field(description="Current data status")
+    accessors: List[str] = Field(
+        default_factory=list, description="Addresses that accessed this data"
+    )
+    transformations: List[ChainTransformation] = Field(
+        default_factory=list, description="Transformations derived from this data"
+    )
+
+
+class AnchorResult(BaseModel):
+    """Result from anchoring a Swarm hash on-chain."""
+
+    tx_hash: str = Field(description="Transaction hash")
+    block_number: int = Field(description="Block number containing the transaction")
+    gas_used: int = Field(description="Gas consumed by the transaction")
+    explorer_url: Optional[str] = Field(
+        default=None, description="Block explorer URL for the transaction"
+    )
+    swarm_hash: str = Field(description="The anchored Swarm reference hash")
+    data_type: str = Field(description="Data type registered on-chain")
+    owner: str = Field(description="Owner address of the registered data")
+
+
+class TransformResult(BaseModel):
+    """Result from recording a data transformation on-chain."""
+
+    tx_hash: str = Field(description="Transaction hash")
+    block_number: int = Field(description="Block number containing the transaction")
+    gas_used: int = Field(description="Gas consumed by the transaction")
+    explorer_url: Optional[str] = Field(
+        default=None, description="Block explorer URL for the transaction"
+    )
+    original_hash: str = Field(description="Original data hash")
+    new_hash: str = Field(description="New (transformed) data hash")
+    description: str = Field(description="Transformation description")
+
+
+class AccessResult(BaseModel):
+    """Result from recording a data access on-chain."""
+
+    tx_hash: str = Field(description="Transaction hash")
+    block_number: int = Field(description="Block number containing the transaction")
+    gas_used: int = Field(description="Gas consumed by the transaction")
+    explorer_url: Optional[str] = Field(
+        default=None, description="Block explorer URL for the transaction"
+    )
+    swarm_hash: str = Field(description="The accessed Swarm reference hash")
+    accessor: str = Field(description="Address of the accessor")
+
+
+class ChainWalletInfo(BaseModel):
+    """Wallet information for chain operations."""
+
+    address: str = Field(description="Ethereum wallet address")
+    balance_wei: int = Field(description="Balance in wei")
+    balance_eth: str = Field(description="Balance formatted as ETH string")
+    chain: str = Field(description="Chain name (e.g., 'base-sepolia')")
+    contract_address: str = Field(description="DataProvenance contract address")

--- a/swarm_provenance_mcp/chain/provider.py
+++ b/swarm_provenance_mcp/chain/provider.py
@@ -1,0 +1,192 @@
+"""
+Chain provider for connecting to EVM-compatible networks.
+
+Manages Web3 connections to Base Sepolia (testnet) and Base (mainnet)
+for interacting with the DataProvenance smart contract.
+
+Requires optional dependencies: pip install -e .[blockchain]
+"""
+
+from typing import Optional
+
+from .exceptions import ChainConfigurationError, ChainConnectionError
+
+# Lazy web3 import
+_Web3 = None
+
+
+def _import_web3():
+    """Lazily import web3 to avoid import errors when not installed."""
+    global _Web3
+    if _Web3 is None:
+        try:
+            from web3 import Web3
+
+            _Web3 = Web3
+        except ImportError as e:
+            raise ChainConfigurationError(
+                "Blockchain dependencies not installed. "
+                "Run: pip install -e .[blockchain]"
+            ) from e
+    return _Web3
+
+
+# Network presets for supported chains
+CHAIN_PRESETS = {
+    "base-sepolia": {
+        "chain_id": 84532,
+        "rpc_url": "https://sepolia.base.org",
+        "explorer_url": "https://sepolia.basescan.org",
+        "contract_address": "0x9a3c6F47B69211F05891CCb7aD33596290b9fE64",
+    },
+    "base": {
+        "chain_id": 8453,
+        "rpc_url": "https://mainnet.base.org",
+        "explorer_url": "https://basescan.org",
+        "contract_address": None,  # Not yet deployed
+    },
+}
+
+
+class ChainProvider:
+    """Provider for Web3 connections to supported EVM chains.
+
+    Handles RPC connection management, health checks, and block explorer
+    URL generation for Base Sepolia and Base mainnet.
+    """
+
+    SUPPORTED_CHAINS = list(CHAIN_PRESETS.keys())
+
+    def __init__(
+        self,
+        chain: str = "base-sepolia",
+        rpc_url: Optional[str] = None,
+        contract_address: Optional[str] = None,
+        explorer_url: Optional[str] = None,
+    ):
+        """
+        Initialize the chain provider.
+
+        Args:
+            chain: Chain name ('base-sepolia' or 'base').
+            rpc_url: Custom RPC URL. If None, uses preset for chain.
+            contract_address: Custom contract address. If None, uses preset.
+            explorer_url: Custom block explorer URL. If None, uses preset.
+
+        Raises:
+            ChainConfigurationError: If chain is unsupported or web3 not installed.
+        """
+        Web3 = _import_web3()
+
+        if chain not in CHAIN_PRESETS:
+            raise ChainConfigurationError(
+                f"Unsupported chain: {chain}. Supported: {self.SUPPORTED_CHAINS}"
+            )
+
+        preset = CHAIN_PRESETS[chain]
+        self.chain = chain
+        self.rpc_url = rpc_url or preset["rpc_url"]
+        self.explorer_url = explorer_url or preset["explorer_url"]
+        self.contract_address = contract_address or preset["contract_address"]
+        self._custom_rpc = rpc_url is not None
+
+        if not self.contract_address:
+            raise ChainConfigurationError(
+                f"No contract address configured for chain '{chain}'. "
+                "Provide one via contract_address parameter or CHAIN_CONTRACT env var."
+            )
+
+        # Initialize Web3 connection
+        self._web3 = Web3(Web3.HTTPProvider(self.rpc_url))
+
+        # When a custom RPC is provided, auto-detect chain ID from the node
+        # (e.g. local Hardhat uses chain ID 31337, not the preset chain ID)
+        if self._custom_rpc:
+            try:
+                self.chain_id = self._web3.eth.chain_id
+            except Exception:
+                self.chain_id = preset["chain_id"]
+        else:
+            self.chain_id = preset["chain_id"]
+
+    @property
+    def web3(self):
+        """Get the Web3 instance."""
+        return self._web3
+
+    def health_check(self) -> bool:
+        """
+        Check if the RPC endpoint is reachable and responding.
+
+        Returns:
+            True if connected and chain ID matches.
+
+        Raises:
+            ChainConnectionError: If connection fails.
+        """
+        try:
+            if not self._web3.is_connected():
+                raise ChainConnectionError(
+                    f"Cannot connect to RPC endpoint: {self.rpc_url}",
+                    rpc_url=self.rpc_url,
+                )
+            actual_chain_id = self._web3.eth.chain_id
+            if actual_chain_id != self.chain_id:
+                raise ChainConnectionError(
+                    f"Chain ID mismatch: expected {self.chain_id}, got {actual_chain_id}",
+                    rpc_url=self.rpc_url,
+                )
+            return True
+        except ChainConnectionError:
+            raise
+        except Exception as e:
+            raise ChainConnectionError(
+                f"RPC health check failed: {e}",
+                rpc_url=self.rpc_url,
+            ) from e
+
+    def get_block_number(self) -> int:
+        """
+        Get the latest block number.
+
+        Returns:
+            The current block number.
+
+        Raises:
+            ChainConnectionError: If RPC call fails.
+        """
+        try:
+            return self._web3.eth.block_number
+        except Exception as e:
+            raise ChainConnectionError(
+                f"Failed to get block number: {e}",
+                rpc_url=self.rpc_url,
+            ) from e
+
+    def get_explorer_tx_url(self, tx_hash: str) -> str:
+        """
+        Get block explorer URL for a transaction.
+
+        Args:
+            tx_hash: Transaction hash (with or without 0x prefix).
+
+        Returns:
+            Full block explorer URL for the transaction.
+        """
+        if not tx_hash.startswith("0x"):
+            tx_hash = "0x" + tx_hash
+        return f"{self.explorer_url}/tx/{tx_hash}"
+
+    def get_explorer_address_url(self, address: str) -> str:
+        """
+        Get block explorer URL for an address.
+
+        Args:
+            address: Ethereum address (with or without 0x prefix).
+
+        Returns:
+            Full block explorer URL for the address.
+        """
+        if not address.startswith("0x"):
+            address = "0x" + address
+        return f"{self.explorer_url}/address/{address}"

--- a/swarm_provenance_mcp/chain/wallet.py
+++ b/swarm_provenance_mcp/chain/wallet.py
@@ -1,0 +1,121 @@
+"""
+Chain wallet for signing transactions.
+
+Manages private key loading, address derivation, transaction signing,
+and ETH balance queries for on-chain operations.
+
+Requires optional dependencies: pip install -e .[blockchain]
+"""
+
+import os
+from typing import Optional
+
+from .exceptions import ChainConfigurationError
+
+# Lazy eth-account import
+_Account = None
+
+
+def _import_eth_account():
+    """Lazily import eth-account to avoid import errors when not installed."""
+    global _Account
+    if _Account is None:
+        try:
+            from eth_account import Account
+
+            _Account = Account
+        except ImportError as e:
+            raise ChainConfigurationError(
+                "Blockchain dependencies not installed. "
+                "Run: pip install -e .[blockchain]"
+            ) from e
+    return _Account
+
+
+class ChainWallet:
+    """Wallet for signing blockchain transactions.
+
+    Loads a private key from an environment variable or direct parameter,
+    derives the corresponding address, and provides transaction signing.
+    """
+
+    def __init__(
+        self,
+        private_key: Optional[str] = None,
+        private_key_env: str = "PROVENANCE_WALLET_KEY",
+    ):
+        """
+        Initialize the wallet.
+
+        Args:
+            private_key: Hex-encoded private key. If None, reads from env var.
+            private_key_env: Environment variable name containing the private key.
+
+        Raises:
+            ChainConfigurationError: If no private key found or key is invalid.
+        """
+        Account = _import_eth_account()
+
+        self._private_key = private_key or os.getenv(private_key_env)
+        if not self._private_key:
+            raise ChainConfigurationError(
+                f"No wallet private key configured. "
+                f"Set {private_key_env} environment variable or pass private_key parameter."
+            )
+
+        # Normalize 0x prefix
+        if not self._private_key.startswith("0x"):
+            self._private_key = "0x" + self._private_key
+
+        # Validate and derive address
+        try:
+            self._account = Account.from_key(self._private_key)
+            self.address = self._account.address
+        except Exception as e:
+            raise ChainConfigurationError(f"Invalid private key: {e}") from e
+
+    def sign_transaction(self, tx: dict) -> bytes:
+        """
+        Sign a transaction dictionary.
+
+        Args:
+            tx: Transaction dict with fields like to, value, data, gas, etc.
+
+        Returns:
+            Raw signed transaction bytes ready for broadcast.
+
+        Raises:
+            ChainConfigurationError: If signing fails.
+        """
+        try:
+            signed = self._account.sign_transaction(tx)
+            return signed.raw_transaction
+        except Exception as e:
+            raise ChainConfigurationError(f"Failed to sign transaction: {e}") from e
+
+    def get_balance(self, web3) -> int:
+        """
+        Get ETH balance of this wallet.
+
+        Args:
+            web3: Web3 instance connected to the target chain.
+
+        Returns:
+            Balance in wei.
+        """
+        return web3.eth.get_balance(self.address)
+
+    def get_balance_eth(self, web3) -> str:
+        """
+        Get ETH balance formatted as a string.
+
+        Args:
+            web3: Web3 instance connected to the target chain.
+
+        Returns:
+            Balance formatted as ETH string (e.g., "0.1234").
+        """
+        from web3 import Web3 as Web3Class
+
+        balance_wei = self.get_balance(web3)
+        return str(Web3Class.from_wei(balance_wei, "ether"))

--- a/swarm_provenance_mcp/config.py
+++ b/swarm_provenance_mcp/config.py
@@ -49,6 +49,49 @@ class Settings(BaseSettings):
         description="Payment mode for gateway requests (free = rate-limited free tier)"
     )
 
+    # Chain Anchoring Configuration
+    chain_enabled: bool = Field(
+        default=False,
+        env="CHAIN_ENABLED",
+        description="Enable on-chain provenance anchoring via DataProvenance contract"
+    )
+
+    chain_name: str = Field(
+        default="base-sepolia",
+        env="CHAIN_NAME",
+        description="Blockchain network name (base-sepolia or base)"
+    )
+
+    provenance_wallet_key: Optional[str] = Field(
+        default=None,
+        env="PROVENANCE_WALLET_KEY",
+        description="Private key for signing chain transactions (hex, with or without 0x)"
+    )
+
+    chain_rpc_url: Optional[str] = Field(
+        default=None,
+        env="CHAIN_RPC_URL",
+        description="Custom RPC endpoint URL (uses chain preset if not set)"
+    )
+
+    chain_contract_address: Optional[str] = Field(
+        default=None,
+        env="CHAIN_CONTRACT",
+        description="Custom DataProvenance contract address (uses chain preset if not set)"
+    )
+
+    chain_explorer_url: Optional[str] = Field(
+        default=None,
+        env="CHAIN_EXPLORER_URL",
+        description="Custom block explorer URL (uses chain preset if not set)"
+    )
+
+    chain_gas_limit: Optional[int] = Field(
+        default=None,
+        env="CHAIN_GAS_LIMIT",
+        description="Explicit gas limit for chain transactions (skips estimation if set)"
+    )
+
     class Config:
         env_file = ".env"
         env_file_encoding = "utf-8"

--- a/swarm_provenance_mcp/server.py
+++ b/swarm_provenance_mcp/server.py
@@ -31,6 +31,38 @@ logger = logging.getLogger(__name__)
 # Global gateway client instance
 gateway_client = SwarmGatewayClient()
 
+# Chain client (initialized when chain_enabled=true and dependencies available)
+chain_client = None
+CHAIN_AVAILABLE = False
+
+if settings.chain_enabled:
+    try:
+        from .chain import CHAIN_AVAILABLE as _chain_avail, ChainClient
+
+        CHAIN_AVAILABLE = _chain_avail
+        if CHAIN_AVAILABLE:
+            chain_client = ChainClient(
+                chain=settings.chain_name,
+                rpc_url=settings.chain_rpc_url,
+                contract_address=settings.chain_contract_address,
+                private_key=settings.provenance_wallet_key,
+                explorer_url=settings.chain_explorer_url,
+                gas_limit=settings.chain_gas_limit,
+            )
+            logger.info(
+                "Chain client initialized: chain=%s contract=%s",
+                chain_client.chain,
+                chain_client.contract_address,
+            )
+        else:
+            logger.warning(
+                "Chain enabled but blockchain dependencies not installed. "
+                "Run: pip install -e .[blockchain]"
+            )
+    except Exception as e:
+        logger.warning("Chain client initialization failed: %s", e)
+        CHAIN_AVAILABLE = False
+
 # Agent-facing instructions sent during MCP initialization handshake
 MCP_INSTRUCTIONS = """
 Swarm Provenance MCP — decentralized storage with cryptographic provenance on the Swarm network.
@@ -63,6 +95,12 @@ ERRORS:
 - "Not usable": stamp expired or not yet propagated — wait or purchase new
 - HTTP 404 on stamp: may be newly purchased, wait ~1 minute and retry
 - Size exceeded: data > 4KB, reduce payload before upload
+
+CHAIN ANCHORING (optional):
+When chain_enabled=true and blockchain dependencies are installed, on-chain provenance tools become available.
+These register Swarm hashes in the DataProvenance smart contract on Base Sepolia, creating an immutable on-chain record.
+Chain tools will be registered as separate tools (anchor_data, verify_chain, etc.) when enabled.
+The health_check tool reports chain status alongside gateway status.
 
 COMPANION SERVERS:
 - swarm_connect gateway (required) — the FastAPI gateway this server talks to, handles Bee node communication
@@ -435,6 +473,7 @@ def create_server() -> Server:
                 return await handle_get_notary_info(arguments)
             elif name == "health_check":
                 return await handle_health_check(arguments)
+            # Chain anchoring tools (#49-#56) will be routed here
             else:
                 return CallToolResult(
                     content=[
@@ -1093,6 +1132,21 @@ async def handle_health_check(arguments: Dict[str, Any]) -> CallToolResult:
             response_text += "\n_recommendations:"
             for rec in recommendations:
                 response_text += f"\n  - {rec}"
+
+        # Chain anchoring status
+        if settings.chain_enabled:
+            if CHAIN_AVAILABLE and chain_client:
+                try:
+                    chain_client.health_check()
+                    response_text += f"\n\n⛓️  Chain: {chain_client.chain} (connected)"
+                    response_text += f"\n   Contract: {chain_client.contract_address}"
+                    response_text += f"\n   Wallet: {chain_client.address}"
+                except Exception as chain_err:
+                    response_text += f"\n\n⛓️  Chain: {settings.chain_name} (error: {chain_err})"
+                    recommendations.append("Chain anchoring enabled but RPC unreachable")
+            else:
+                response_text += f"\n\n⛓️  Chain: enabled but dependencies not installed"
+                recommendations.append("Install blockchain deps: pip install -e .[blockchain]")
 
         # Cross-server coordination info
         response_text += f"\n_companion_servers:"

--- a/tests/test_chain_client.py
+++ b/tests/test_chain_client.py
@@ -1,0 +1,1484 @@
+"""Tests for the chain client module and chain subpackage."""
+
+import json
+import os
+import pytest
+from unittest.mock import MagicMock, patch, PropertyMock
+
+from swarm_provenance_mcp.chain.exceptions import (
+    ChainConfigurationError,
+    ChainConnectionError,
+    ChainTransactionError,
+    ChainValidationError,
+    DataAlreadyRegisteredError,
+    DataNotRegisteredError,
+)
+from swarm_provenance_mcp.chain.models import (
+    AnchorResult,
+    AccessResult,
+    ChainProvenanceRecord,
+    ChainWalletInfo,
+    DataStatusEnum,
+    TransformResult,
+)
+
+
+# Test constants
+DUMMY_PRIVATE_KEY = "0x" + "a" * 64
+DUMMY_ADDRESS = "0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00"
+DUMMY_HASH = "a" * 64
+DUMMY_HASH_BYTES = bytes.fromhex(DUMMY_HASH)
+DUMMY_CONTRACT = "0x9a3c6F47B69211F05891CCb7aD33596290b9fE64"
+DUMMY_TX_HASH_BYTES = bytes.fromhex("bb" * 32)
+ZERO_ADDRESS = "0x" + "0" * 40
+
+
+@pytest.fixture
+def mock_chain_deps():
+    """Mock web3 and eth-account dependencies for chain tests."""
+    with patch.dict(os.environ, {"PROVENANCE_WALLET_KEY": DUMMY_PRIVATE_KEY}):
+        # Mock eth_account
+        mock_account = MagicMock()
+        mock_account.address = DUMMY_ADDRESS
+        mock_account.sign_transaction.return_value = MagicMock(
+            raw_transaction=b"\x00" * 32
+        )
+
+        mock_account_class = MagicMock()
+        mock_account_class.from_key.return_value = mock_account
+
+        # Mock web3 instance
+        mock_web3_instance = MagicMock()
+        mock_web3_instance.to_checksum_address = lambda x: x
+        mock_web3_instance.eth.chain_id = 84532
+        mock_web3_instance.eth.block_number = 12345678
+        mock_web3_instance.eth.get_balance.return_value = (
+            1_000_000_000_000_000_000  # 1 ETH
+        )
+        mock_web3_instance.eth.get_transaction_count.return_value = 0
+        mock_web3_instance.eth.estimate_gas.return_value = 100_000
+        mock_web3_instance.eth.send_raw_transaction.return_value = DUMMY_TX_HASH_BYTES
+        mock_web3_instance.eth.wait_for_transaction_receipt.return_value = {
+            "status": 1,
+            "transactionHash": DUMMY_TX_HASH_BYTES,
+            "blockNumber": 12345679,
+            "gasUsed": 95_000,
+        }
+        mock_web3_instance.is_connected.return_value = True
+
+        # Mock contract
+        mock_contract = MagicMock()
+        mock_web3_instance.eth.contract.return_value = mock_contract
+
+        # Mock build_transaction for all contract functions
+        mock_contract.functions.registerData.return_value.build_transaction.return_value = {
+            "from": DUMMY_ADDRESS,
+            "to": DUMMY_CONTRACT,
+            "data": "0x",
+        }
+        mock_contract.functions.registerDataFor.return_value.build_transaction.return_value = {
+            "from": DUMMY_ADDRESS,
+            "to": DUMMY_CONTRACT,
+            "data": "0x",
+        }
+        mock_contract.functions.batchRegisterData.return_value.build_transaction.return_value = {
+            "from": DUMMY_ADDRESS,
+            "to": DUMMY_CONTRACT,
+            "data": "0x",
+        }
+        mock_contract.functions.recordTransformation.return_value.build_transaction.return_value = {
+            "from": DUMMY_ADDRESS,
+            "to": DUMMY_CONTRACT,
+            "data": "0x",
+        }
+        mock_contract.functions.recordAccess.return_value.build_transaction.return_value = {
+            "from": DUMMY_ADDRESS,
+            "to": DUMMY_CONTRACT,
+            "data": "0x",
+        }
+        mock_contract.functions.batchRecordAccess.return_value.build_transaction.return_value = {
+            "from": DUMMY_ADDRESS,
+            "to": DUMMY_CONTRACT,
+            "data": "0x",
+        }
+        mock_contract.functions.setDataStatus.return_value.build_transaction.return_value = {
+            "from": DUMMY_ADDRESS,
+            "to": DUMMY_CONTRACT,
+            "data": "0x",
+        }
+        mock_contract.functions.transferDataOwnership.return_value.build_transaction.return_value = {
+            "from": DUMMY_ADDRESS,
+            "to": DUMMY_CONTRACT,
+            "data": "0x",
+        }
+        mock_contract.functions.setDelegate.return_value.build_transaction.return_value = {
+            "from": DUMMY_ADDRESS,
+            "to": DUMMY_CONTRACT,
+            "data": "0x",
+        }
+        mock_contract.functions.batchSetDataStatus.return_value.build_transaction.return_value = {
+            "from": DUMMY_ADDRESS,
+            "to": DUMMY_CONTRACT,
+            "data": "0x",
+        }
+
+        # Mock read functions
+        mock_contract.functions.getDataRecord.return_value.call.return_value = (
+            DUMMY_HASH_BYTES,  # dataHash
+            DUMMY_ADDRESS,  # owner
+            1700000000,  # timestamp
+            "swarm-provenance",  # dataType
+            [],  # transformations
+            [],  # accessors
+            0,  # status (ACTIVE)
+        )
+        mock_contract.functions.getUserDataRecords.return_value.call.return_value = [
+            DUMMY_HASH_BYTES,
+        ]
+        mock_contract.functions.getUserDataRecordsCount.return_value.call.return_value = (
+            1
+        )
+        mock_contract.functions.getUserDataRecordsPaginated.return_value.call.return_value = [
+            DUMMY_HASH_BYTES,
+        ]
+        mock_contract.functions.hasAddressAccessed.return_value.call.return_value = True
+        mock_contract.functions.isAuthorizedDelegate.return_value.call.return_value = (
+            False
+        )
+
+        # Mock Web3 class
+        mock_web3_class = MagicMock(return_value=mock_web3_instance)
+        mock_web3_class.HTTPProvider = MagicMock()
+        mock_web3_class.from_wei = lambda val, unit: str(val / 10**18)
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "eth_account": MagicMock(Account=mock_account_class),
+                "web3": MagicMock(Web3=mock_web3_class),
+            },
+        ):
+            # Reset lazy import globals so they pick up the mocked modules
+            import swarm_provenance_mcp.chain.provider as provider_module
+            import swarm_provenance_mcp.chain.wallet as wallet_module
+
+            provider_module._Web3 = None
+            wallet_module._Account = None
+
+            yield {
+                "account": mock_account,
+                "account_class": mock_account_class,
+                "web3_instance": mock_web3_instance,
+                "web3_class": mock_web3_class,
+                "contract": mock_contract,
+            }
+
+            # Reset lazy import globals so real modules are re-imported next time
+            provider_module._Web3 = None
+            wallet_module._Account = None
+
+
+# --- Contract validation tests ---
+
+
+class TestContractValidation:
+    """Tests for contract-level validation helpers."""
+
+    def test_normalize_hash_valid_hex(self):
+        """Tests normalizing a valid 64-char hex hash."""
+        from swarm_provenance_mcp.chain.contract import _normalize_hash
+
+        result = _normalize_hash(DUMMY_HASH)
+        assert result == DUMMY_HASH_BYTES
+        assert len(result) == 32
+
+    def test_normalize_hash_with_0x_prefix(self):
+        """Tests normalizing a hash with 0x prefix."""
+        from swarm_provenance_mcp.chain.contract import _normalize_hash
+
+        result = _normalize_hash("0x" + DUMMY_HASH)
+        assert result == DUMMY_HASH_BYTES
+
+    def test_normalize_hash_invalid_length(self):
+        """Tests that short hash raises validation error."""
+        from swarm_provenance_mcp.chain.contract import _normalize_hash
+
+        with pytest.raises(ChainValidationError) as exc_info:
+            _normalize_hash("abcdef")
+        assert "64 hex characters" in str(exc_info.value)
+
+    def test_normalize_hash_invalid_hex(self):
+        """Tests that non-hex characters raise validation error."""
+        from swarm_provenance_mcp.chain.contract import _normalize_hash
+
+        with pytest.raises(ChainValidationError) as exc_info:
+            _normalize_hash("g" * 64)
+        assert "Invalid hex" in str(exc_info.value)
+
+    def test_normalize_hash_raw_bytes(self):
+        """Tests normalizing raw 32-byte input."""
+        from swarm_provenance_mcp.chain.contract import _normalize_hash
+
+        result = _normalize_hash(DUMMY_HASH_BYTES)
+        assert result == DUMMY_HASH_BYTES
+
+    def test_normalize_hash_wrong_bytes_length(self):
+        """Tests that wrong byte length raises error."""
+        from swarm_provenance_mcp.chain.contract import _normalize_hash
+
+        with pytest.raises(ChainValidationError) as exc_info:
+            _normalize_hash(b"\x00" * 16)
+        assert "32 bytes" in str(exc_info.value)
+
+    def test_validate_data_type_valid(self):
+        """Tests valid data type string."""
+        from swarm_provenance_mcp.chain.contract import _validate_data_type
+
+        result = _validate_data_type("swarm-provenance")
+        assert result == "swarm-provenance"
+
+    def test_validate_data_type_too_long(self):
+        """Tests that data type exceeding max length raises error."""
+        from swarm_provenance_mcp.chain.contract import _validate_data_type
+
+        with pytest.raises(ChainValidationError) as exc_info:
+            _validate_data_type("x" * 65)
+        assert "64" in str(exc_info.value)
+
+    def test_validate_transformation_valid(self):
+        """Tests valid transformation description."""
+        from swarm_provenance_mcp.chain.contract import _validate_transformation
+
+        result = _validate_transformation("Filtered and anonymized")
+        assert result == "Filtered and anonymized"
+
+    def test_validate_transformation_too_long(self):
+        """Tests that transformation exceeding max length raises error."""
+        from swarm_provenance_mcp.chain.contract import _validate_transformation
+
+        with pytest.raises(ChainValidationError) as exc_info:
+            _validate_transformation("x" * 257)
+        assert "256" in str(exc_info.value)
+
+
+class TestContractBatchValidation:
+    """Tests for batch operation validation."""
+
+    def test_batch_register_mismatched_lengths(self, mock_chain_deps):
+        """Tests that mismatched array lengths raise error."""
+        from swarm_provenance_mcp.chain.contract import DataProvenanceContract
+
+        contract = DataProvenanceContract(
+            web3=mock_chain_deps["web3_instance"],
+            contract_address=DUMMY_CONTRACT,
+        )
+
+        with pytest.raises(ChainValidationError) as exc_info:
+            contract.build_batch_register_data_tx(
+                data_hashes=[DUMMY_HASH],
+                data_types=["type1", "type2"],  # mismatched
+                sender=DUMMY_ADDRESS,
+            )
+        assert "same length" in str(exc_info.value)
+
+    def test_batch_register_exceeds_limit(self, mock_chain_deps):
+        """Tests that exceeding batch limit raises error."""
+        from swarm_provenance_mcp.chain.contract import (
+            DataProvenanceContract,
+            MAX_BATCH_REGISTER,
+        )
+
+        contract = DataProvenanceContract(
+            web3=mock_chain_deps["web3_instance"],
+            contract_address=DUMMY_CONTRACT,
+        )
+
+        with pytest.raises(ChainValidationError) as exc_info:
+            contract.build_batch_register_data_tx(
+                data_hashes=[DUMMY_HASH] * (MAX_BATCH_REGISTER + 1),
+                data_types=["type"] * (MAX_BATCH_REGISTER + 1),
+                sender=DUMMY_ADDRESS,
+            )
+        assert "maximum" in str(exc_info.value).lower()
+
+    def test_batch_access_exceeds_limit(self, mock_chain_deps):
+        """Tests that exceeding batch access limit raises error."""
+        from swarm_provenance_mcp.chain.contract import (
+            DataProvenanceContract,
+            MAX_BATCH_ACCESS,
+        )
+
+        contract = DataProvenanceContract(
+            web3=mock_chain_deps["web3_instance"],
+            contract_address=DUMMY_CONTRACT,
+        )
+
+        with pytest.raises(ChainValidationError) as exc_info:
+            contract.build_batch_record_access_tx(
+                data_hashes=[DUMMY_HASH] * (MAX_BATCH_ACCESS + 1),
+                sender=DUMMY_ADDRESS,
+            )
+        assert "maximum" in str(exc_info.value).lower()
+
+
+class TestABILoading:
+    """Tests for ABI file loading."""
+
+    def test_load_abi_success(self):
+        """Tests that the bundled ABI loads correctly."""
+        from swarm_provenance_mcp.chain.contract import _load_abi
+
+        abi = _load_abi()
+        assert isinstance(abi, list)
+        assert len(abi) > 0
+
+        # Should contain registerData function
+        func_names = [e["name"] for e in abi if e.get("type") == "function"]
+        assert "registerData" in func_names
+        assert "getDataRecord" in func_names
+        assert "recordAccess" in func_names
+
+    def test_load_abi_missing_file(self):
+        """Tests that missing ABI file raises config error."""
+        from swarm_provenance_mcp.chain.contract import _load_abi
+        from pathlib import Path
+
+        with patch.object(Path, "parent", new_callable=PropertyMock) as mock_parent:
+            mock_parent.return_value = Path("/nonexistent")
+            # Need to patch at the open level
+            with patch(
+                "builtins.open", side_effect=FileNotFoundError("no such file")
+            ):
+                with pytest.raises(ChainConfigurationError) as exc_info:
+                    _load_abi()
+                assert "Failed to load" in str(exc_info.value)
+
+
+# --- Provider tests ---
+
+
+class TestChainProvider:
+    """Tests for ChainProvider initialization and methods."""
+
+    def test_unsupported_chain_raises_error(self, mock_chain_deps):
+        """Tests that unsupported chain name raises error."""
+        from swarm_provenance_mcp.chain.provider import ChainProvider
+
+        with pytest.raises(ChainConfigurationError) as exc_info:
+            ChainProvider(chain="ethereum-mainnet")
+        assert "Unsupported chain" in str(exc_info.value)
+
+    def test_valid_init_base_sepolia(self, mock_chain_deps):
+        """Tests successful initialization for base-sepolia."""
+        from swarm_provenance_mcp.chain.provider import ChainProvider
+
+        provider = ChainProvider(chain="base-sepolia")
+
+        assert provider.chain == "base-sepolia"
+        assert provider.chain_id == 84532
+        assert (
+            provider.contract_address
+            == "0x9a3c6F47B69211F05891CCb7aD33596290b9fE64"
+        )
+
+    def test_custom_rpc_url(self, mock_chain_deps):
+        """Tests that custom RPC URL is used."""
+        from swarm_provenance_mcp.chain.provider import ChainProvider
+
+        provider = ChainProvider(
+            chain="base-sepolia",
+            rpc_url="https://custom.rpc.io",
+        )
+        assert provider.rpc_url == "https://custom.rpc.io"
+
+    def test_custom_contract_address(self, mock_chain_deps):
+        """Tests that custom contract address is used."""
+        from swarm_provenance_mcp.chain.provider import ChainProvider
+
+        custom_addr = "0x1234567890abcdef1234567890abcdef12345678"
+        provider = ChainProvider(
+            chain="base-sepolia",
+            contract_address=custom_addr,
+        )
+        assert provider.contract_address == custom_addr
+
+    def test_custom_explorer_url(self, mock_chain_deps):
+        """Tests that custom explorer URL overrides the preset."""
+        from swarm_provenance_mcp.chain.provider import ChainProvider
+
+        provider = ChainProvider(
+            chain="base-sepolia",
+            explorer_url="https://custom-explorer.io",
+        )
+        assert provider.explorer_url == "https://custom-explorer.io"
+
+    def test_default_explorer_url(self, mock_chain_deps):
+        """Tests that preset explorer URL is used when no override given."""
+        from swarm_provenance_mcp.chain.provider import ChainProvider
+
+        provider = ChainProvider(chain="base-sepolia")
+        assert provider.explorer_url == "https://sepolia.basescan.org"
+
+    def test_custom_explorer_url_in_tx_url(self, mock_chain_deps):
+        """Tests that custom explorer URL is used in generated TX URLs."""
+        from swarm_provenance_mcp.chain.provider import ChainProvider
+
+        provider = ChainProvider(
+            chain="base-sepolia",
+            explorer_url="https://custom-explorer.io",
+        )
+        url = provider.get_explorer_tx_url("0xabc123")
+        assert url == "https://custom-explorer.io/tx/0xabc123"
+
+    def test_base_mainnet_no_contract_raises_error(self, mock_chain_deps):
+        """Tests that base mainnet without contract raises error."""
+        from swarm_provenance_mcp.chain.provider import ChainProvider
+
+        with pytest.raises(ChainConfigurationError) as exc_info:
+            ChainProvider(chain="base")
+        assert "No contract address" in str(exc_info.value)
+
+    def test_health_check_success(self, mock_chain_deps):
+        """Tests successful health check."""
+        from swarm_provenance_mcp.chain.provider import ChainProvider
+
+        provider = ChainProvider(chain="base-sepolia")
+        assert provider.health_check() is True
+
+    def test_health_check_not_connected(self, mock_chain_deps):
+        """Tests health check when not connected."""
+        from swarm_provenance_mcp.chain.provider import ChainProvider
+
+        mock_chain_deps["web3_instance"].is_connected.return_value = False
+        provider = ChainProvider(chain="base-sepolia")
+
+        with pytest.raises(ChainConnectionError) as exc_info:
+            provider.health_check()
+        assert "Cannot connect" in str(exc_info.value)
+
+    def test_health_check_chain_id_mismatch(self, mock_chain_deps):
+        """Tests health check with wrong chain ID."""
+        from swarm_provenance_mcp.chain.provider import ChainProvider
+
+        mock_chain_deps["web3_instance"].eth.chain_id = 9999
+        provider = ChainProvider(chain="base-sepolia")
+
+        with pytest.raises(ChainConnectionError) as exc_info:
+            provider.health_check()
+        assert "Chain ID mismatch" in str(exc_info.value)
+
+    def test_get_block_number(self, mock_chain_deps):
+        """Tests getting block number."""
+        from swarm_provenance_mcp.chain.provider import ChainProvider
+
+        provider = ChainProvider(chain="base-sepolia")
+        assert provider.get_block_number() == 12345678
+
+    def test_explorer_tx_url(self, mock_chain_deps):
+        """Tests generating transaction explorer URL."""
+        from swarm_provenance_mcp.chain.provider import ChainProvider
+
+        provider = ChainProvider(chain="base-sepolia")
+        url = provider.get_explorer_tx_url("0xabc123")
+        assert url == "https://sepolia.basescan.org/tx/0xabc123"
+
+    def test_explorer_tx_url_without_prefix(self, mock_chain_deps):
+        """Tests explorer URL auto-adds 0x prefix."""
+        from swarm_provenance_mcp.chain.provider import ChainProvider
+
+        provider = ChainProvider(chain="base-sepolia")
+        url = provider.get_explorer_tx_url("abc123")
+        assert url == "https://sepolia.basescan.org/tx/0xabc123"
+
+    def test_explorer_address_url(self, mock_chain_deps):
+        """Tests generating address explorer URL."""
+        from swarm_provenance_mcp.chain.provider import ChainProvider
+
+        provider = ChainProvider(chain="base-sepolia")
+        url = provider.get_explorer_address_url(DUMMY_ADDRESS)
+        assert "sepolia.basescan.org/address/" in url
+
+
+# --- Wallet tests ---
+
+
+class TestChainWallet:
+    """Tests for ChainWallet initialization and methods."""
+
+    def test_missing_key_raises_error(self, mock_chain_deps):
+        """Tests that missing private key raises error."""
+        with patch.dict(os.environ, {}, clear=True):
+            from swarm_provenance_mcp.chain.wallet import ChainWallet
+
+            with pytest.raises(ChainConfigurationError) as exc_info:
+                ChainWallet()
+            assert "No wallet private key" in str(exc_info.value)
+
+    def test_valid_init_with_env_key(self, mock_chain_deps):
+        """Tests successful init from environment variable."""
+        from swarm_provenance_mcp.chain.wallet import ChainWallet
+
+        wallet = ChainWallet()
+        assert wallet.address == DUMMY_ADDRESS
+
+    def test_valid_init_with_direct_key(self, mock_chain_deps):
+        """Tests successful init with direct private key."""
+        from swarm_provenance_mcp.chain.wallet import ChainWallet
+
+        wallet = ChainWallet(private_key=DUMMY_PRIVATE_KEY)
+        assert wallet.address == DUMMY_ADDRESS
+
+    def test_key_without_0x_prefix(self, mock_chain_deps):
+        """Tests that key without 0x prefix gets normalized."""
+        from swarm_provenance_mcp.chain.wallet import ChainWallet
+
+        wallet = ChainWallet(private_key="a" * 64)
+        assert wallet._private_key == DUMMY_PRIVATE_KEY
+
+    def test_sign_transaction(self, mock_chain_deps):
+        """Tests transaction signing."""
+        from swarm_provenance_mcp.chain.wallet import ChainWallet
+
+        wallet = ChainWallet()
+        raw = wallet.sign_transaction({"to": DUMMY_CONTRACT, "value": 0})
+        assert isinstance(raw, bytes)
+
+    def test_get_balance(self, mock_chain_deps):
+        """Tests balance retrieval."""
+        from swarm_provenance_mcp.chain.wallet import ChainWallet
+
+        wallet = ChainWallet()
+        balance = wallet.get_balance(mock_chain_deps["web3_instance"])
+        assert balance == 1_000_000_000_000_000_000
+
+
+# --- ChainClient tests ---
+
+
+class TestChainClientInit:
+    """Tests for ChainClient initialization."""
+
+    def test_valid_init(self, mock_chain_deps):
+        """Tests successful initialization."""
+        from swarm_provenance_mcp.chain.client import ChainClient
+
+        client = ChainClient(chain="base-sepolia")
+
+        assert client.address == DUMMY_ADDRESS
+        assert client.chain == "base-sepolia"
+        assert client.contract_address == DUMMY_CONTRACT
+
+    def test_explorer_url_passthrough(self, mock_chain_deps):
+        """Tests that explorer_url is passed through to ChainProvider."""
+        from swarm_provenance_mcp.chain.client import ChainClient
+
+        # Pre-check expects unregistered hash
+        mock_chain_deps[
+            "contract"
+        ].functions.getDataRecord.return_value.call.return_value = (
+            DUMMY_HASH_BYTES,
+            ZERO_ADDRESS,
+            0,
+            "",
+            [],
+            [],
+            0,
+        )
+
+        client = ChainClient(
+            chain="base-sepolia",
+            explorer_url="https://custom-explorer.io",
+        )
+        assert client._provider.explorer_url == "https://custom-explorer.io"
+
+        # Verify explorer URL is used in anchor results
+        result = client.anchor(swarm_hash=DUMMY_HASH)
+        assert "custom-explorer.io" in result.explorer_url
+
+    def test_missing_deps_shows_helpful_message(self):
+        """Tests that missing blockchain deps give clear error."""
+        with patch.dict(os.environ, {"PROVENANCE_WALLET_KEY": DUMMY_PRIVATE_KEY}):
+            with patch.dict("sys.modules", {"web3": None}):
+                import swarm_provenance_mcp.chain.provider as pmod
+
+                pmod._Web3 = None
+
+                with pytest.raises((ChainConfigurationError, ImportError)):
+                    from swarm_provenance_mcp.chain.client import ChainClient
+
+                    ChainClient()
+
+
+class TestChainClientAnchor:
+    """Tests for anchor (register data) operations."""
+
+    def test_anchor_success(self, mock_chain_deps):
+        """Tests successful data anchoring."""
+        from swarm_provenance_mcp.chain.client import ChainClient
+
+        # Pre-check expects unregistered hash (zero-address owner)
+        mock_chain_deps[
+            "contract"
+        ].functions.getDataRecord.return_value.call.return_value = (
+            DUMMY_HASH_BYTES,
+            ZERO_ADDRESS,
+            0,
+            "",
+            [],
+            [],
+            0,
+        )
+
+        client = ChainClient(chain="base-sepolia")
+        result = client.anchor(swarm_hash=DUMMY_HASH, data_type="test-data")
+
+        assert isinstance(result, AnchorResult)
+        assert result.swarm_hash == DUMMY_HASH
+        assert result.data_type == "test-data"
+        assert result.owner == DUMMY_ADDRESS
+        assert result.block_number == 12345679
+        assert result.gas_used == 95_000
+        assert "sepolia.basescan.org" in result.explorer_url
+
+    def test_anchor_default_data_type(self, mock_chain_deps):
+        """Tests anchor uses default data type."""
+        from swarm_provenance_mcp.chain.client import ChainClient
+
+        # Pre-check expects unregistered hash
+        mock_chain_deps[
+            "contract"
+        ].functions.getDataRecord.return_value.call.return_value = (
+            DUMMY_HASH_BYTES,
+            ZERO_ADDRESS,
+            0,
+            "",
+            [],
+            [],
+            0,
+        )
+
+        client = ChainClient(chain="base-sepolia")
+        result = client.anchor(swarm_hash=DUMMY_HASH)
+
+        assert result.data_type == "swarm-provenance"
+
+    def test_anchor_for_success(self, mock_chain_deps):
+        """Tests anchoring on behalf of another owner."""
+        from swarm_provenance_mcp.chain.client import ChainClient
+
+        # Pre-check expects unregistered hash
+        mock_chain_deps[
+            "contract"
+        ].functions.getDataRecord.return_value.call.return_value = (
+            DUMMY_HASH_BYTES,
+            ZERO_ADDRESS,
+            0,
+            "",
+            [],
+            [],
+            0,
+        )
+
+        other_owner = "0x1111111111111111111111111111111111111111"
+        client = ChainClient(chain="base-sepolia")
+        result = client.anchor_for(
+            swarm_hash=DUMMY_HASH,
+            owner=other_owner,
+        )
+
+        assert isinstance(result, AnchorResult)
+        assert result.owner == other_owner
+
+    def test_batch_anchor_success(self, mock_chain_deps):
+        """Tests batch anchoring."""
+        from swarm_provenance_mcp.chain.client import ChainClient
+
+        hash2 = "b" * 64
+        client = ChainClient(chain="base-sepolia")
+        result = client.batch_anchor(
+            swarm_hashes=[DUMMY_HASH, hash2],
+            data_types=["type1", "type2"],
+        )
+
+        assert isinstance(result, AnchorResult)
+        assert result.swarm_hash == DUMMY_HASH
+
+    def test_anchor_invalid_hash(self, mock_chain_deps):
+        """Tests that invalid hash raises validation error."""
+        from swarm_provenance_mcp.chain.client import ChainClient
+
+        client = ChainClient(chain="base-sepolia")
+        with pytest.raises(ChainValidationError):
+            client.anchor(swarm_hash="tooshort")
+
+
+class TestChainClientAlreadyRegistered:
+    """Tests for already-registered hash pre-check in anchor/anchor_for."""
+
+    def test_anchor_raises_already_registered(self, mock_chain_deps):
+        """Tests that anchoring an already-registered hash raises DataAlreadyRegisteredError."""
+        from swarm_provenance_mcp.chain.client import ChainClient
+
+        # Default mock returns a registered record (owner=DUMMY_ADDRESS)
+        mock_chain_deps[
+            "contract"
+        ].functions.getDataRecord.return_value.call.return_value = (
+            DUMMY_HASH_BYTES,
+            DUMMY_ADDRESS,
+            1700000000,
+            "swarm-provenance",
+            [],
+            [],
+            0,
+        )
+
+        client = ChainClient(chain="base-sepolia")
+        with pytest.raises(DataAlreadyRegisteredError) as exc_info:
+            client.anchor(swarm_hash=DUMMY_HASH)
+        assert exc_info.value.data_hash == DUMMY_HASH
+        assert exc_info.value.owner == DUMMY_ADDRESS
+        assert exc_info.value.timestamp == 1700000000
+        assert exc_info.value.data_type == "swarm-provenance"
+
+    def test_anchor_for_raises_already_registered(self, mock_chain_deps):
+        """Tests that anchor_for on already-registered hash raises DataAlreadyRegisteredError."""
+        from swarm_provenance_mcp.chain.client import ChainClient
+
+        mock_chain_deps[
+            "contract"
+        ].functions.getDataRecord.return_value.call.return_value = (
+            DUMMY_HASH_BYTES,
+            DUMMY_ADDRESS,
+            1700000000,
+            "swarm-provenance",
+            [],
+            [],
+            0,
+        )
+
+        other_owner = "0x1111111111111111111111111111111111111111"
+        client = ChainClient(chain="base-sepolia")
+        with pytest.raises(DataAlreadyRegisteredError) as exc_info:
+            client.anchor_for(swarm_hash=DUMMY_HASH, owner=other_owner)
+        assert exc_info.value.data_hash == DUMMY_HASH
+
+    def test_anchor_succeeds_when_not_registered(self, mock_chain_deps):
+        """Tests that anchor succeeds when hash is not yet registered."""
+        from swarm_provenance_mcp.chain.client import ChainClient
+
+        # Return zero-address owner = not registered
+        mock_chain_deps[
+            "contract"
+        ].functions.getDataRecord.return_value.call.return_value = (
+            DUMMY_HASH_BYTES,
+            ZERO_ADDRESS,
+            0,
+            "",
+            [],
+            [],
+            0,
+        )
+
+        client = ChainClient(chain="base-sepolia")
+        result = client.anchor(swarm_hash=DUMMY_HASH)
+        assert isinstance(result, AnchorResult)
+        assert result.swarm_hash == DUMMY_HASH
+
+
+class TestChainClientTransform:
+    """Tests for transform operations."""
+
+    def test_transform_success(self, mock_chain_deps):
+        """Tests successful transformation recording."""
+        from swarm_provenance_mcp.chain.client import ChainClient
+
+        new_hash = "b" * 64
+        client = ChainClient(chain="base-sepolia")
+        result = client.transform(
+            original_hash=DUMMY_HASH,
+            new_hash=new_hash,
+            description="Filtered PII",
+        )
+
+        assert isinstance(result, TransformResult)
+        assert result.original_hash == DUMMY_HASH
+        assert result.new_hash == new_hash
+        assert result.description == "Filtered PII"
+
+
+class TestChainClientAccess:
+    """Tests for access recording operations."""
+
+    def test_access_success(self, mock_chain_deps):
+        """Tests successful access recording."""
+        from swarm_provenance_mcp.chain.client import ChainClient
+
+        client = ChainClient(chain="base-sepolia")
+        result = client.access(swarm_hash=DUMMY_HASH)
+
+        assert isinstance(result, AccessResult)
+        assert result.swarm_hash == DUMMY_HASH
+        assert result.accessor == DUMMY_ADDRESS
+
+    def test_batch_access_success(self, mock_chain_deps):
+        """Tests batch access recording."""
+        from swarm_provenance_mcp.chain.client import ChainClient
+
+        hash2 = "b" * 64
+        client = ChainClient(chain="base-sepolia")
+        result = client.batch_access(swarm_hashes=[DUMMY_HASH, hash2])
+
+        assert isinstance(result, AccessResult)
+        assert result.swarm_hash == DUMMY_HASH
+
+
+class TestChainClientStatus:
+    """Tests for status and ownership operations."""
+
+    def test_set_status_success(self, mock_chain_deps):
+        """Tests setting data status."""
+        from swarm_provenance_mcp.chain.client import ChainClient
+
+        client = ChainClient(chain="base-sepolia")
+        result = client.set_status(swarm_hash=DUMMY_HASH, status=1)  # RESTRICTED
+
+        assert isinstance(result, AnchorResult)
+        assert result.swarm_hash == DUMMY_HASH
+
+    def test_transfer_ownership_success(self, mock_chain_deps):
+        """Tests transferring data ownership."""
+        from swarm_provenance_mcp.chain.client import ChainClient
+
+        new_owner = "0x1111111111111111111111111111111111111111"
+        client = ChainClient(chain="base-sepolia")
+        result = client.transfer_ownership(
+            swarm_hash=DUMMY_HASH,
+            new_owner=new_owner,
+        )
+
+        assert isinstance(result, AnchorResult)
+        assert result.owner == new_owner
+
+    def test_set_delegate_success(self, mock_chain_deps):
+        """Tests authorizing a delegate."""
+        from swarm_provenance_mcp.chain.client import ChainClient
+
+        delegate = "0x2222222222222222222222222222222222222222"
+        client = ChainClient(chain="base-sepolia")
+        result = client.set_delegate(delegate=delegate, authorized=True)
+
+        assert isinstance(result, AnchorResult)
+
+
+class TestChainClientRead:
+    """Tests for read operations."""
+
+    def test_get_record_success(self, mock_chain_deps):
+        """Tests getting an on-chain record."""
+        from swarm_provenance_mcp.chain.client import ChainClient
+
+        client = ChainClient(chain="base-sepolia")
+        record = client.get(swarm_hash=DUMMY_HASH)
+
+        assert isinstance(record, ChainProvenanceRecord)
+        assert record.owner == DUMMY_ADDRESS
+        assert record.data_type == "swarm-provenance"
+        assert record.status == DataStatusEnum.ACTIVE
+
+    def test_get_unregistered_hash_raises_error(self, mock_chain_deps):
+        """Tests that unregistered hash raises DataNotRegisteredError."""
+        from swarm_provenance_mcp.chain.client import ChainClient
+
+        # Make the contract return zero address (not registered)
+        mock_chain_deps[
+            "contract"
+        ].functions.getDataRecord.return_value.call.return_value = (
+            DUMMY_HASH_BYTES,
+            ZERO_ADDRESS,
+            0,
+            "",
+            [],
+            [],
+            0,
+        )
+
+        client = ChainClient(chain="base-sepolia")
+        with pytest.raises(DataNotRegisteredError) as exc_info:
+            client.get(swarm_hash=DUMMY_HASH)
+        assert exc_info.value.data_hash == DUMMY_HASH
+
+    def test_verify_registered(self, mock_chain_deps):
+        """Tests verifying a registered hash."""
+        from swarm_provenance_mcp.chain.client import ChainClient
+
+        client = ChainClient(chain="base-sepolia")
+        assert client.verify(swarm_hash=DUMMY_HASH) is True
+
+    def test_verify_unregistered(self, mock_chain_deps):
+        """Tests verifying an unregistered hash."""
+        from swarm_provenance_mcp.chain.client import ChainClient
+
+        mock_chain_deps[
+            "contract"
+        ].functions.getDataRecord.return_value.call.return_value = (
+            DUMMY_HASH_BYTES,
+            ZERO_ADDRESS,
+            0,
+            "",
+            [],
+            [],
+            0,
+        )
+
+        client = ChainClient(chain="base-sepolia")
+        assert client.verify(swarm_hash=DUMMY_HASH) is False
+
+    def test_balance_info(self, mock_chain_deps):
+        """Tests getting wallet balance info."""
+        from swarm_provenance_mcp.chain.client import ChainClient
+
+        client = ChainClient(chain="base-sepolia")
+        info = client.balance()
+
+        assert isinstance(info, ChainWalletInfo)
+        assert info.address == DUMMY_ADDRESS
+        assert info.balance_wei == 1_000_000_000_000_000_000
+        assert info.chain == "base-sepolia"
+        assert info.contract_address == DUMMY_CONTRACT
+
+    def test_health_check(self, mock_chain_deps):
+        """Tests chain health check via client."""
+        from swarm_provenance_mcp.chain.client import ChainClient
+
+        client = ChainClient(chain="base-sepolia")
+        assert client.health_check() is True
+
+
+class TestChainClientTransaction:
+    """Tests for transaction sending edge cases."""
+
+    def test_transaction_reverted(self, mock_chain_deps):
+        """Tests that reverted transaction raises error."""
+        from swarm_provenance_mcp.chain.client import ChainClient
+
+        # Pre-check expects unregistered hash
+        mock_chain_deps[
+            "contract"
+        ].functions.getDataRecord.return_value.call.return_value = (
+            DUMMY_HASH_BYTES,
+            ZERO_ADDRESS,
+            0,
+            "",
+            [],
+            [],
+            0,
+        )
+
+        # Make receipt indicate failure
+        mock_chain_deps["web3_instance"].eth.wait_for_transaction_receipt.return_value = {
+            "status": 0,
+            "transactionHash": DUMMY_TX_HASH_BYTES,
+            "blockNumber": 12345679,
+            "gasUsed": 100_000,
+        }
+
+        client = ChainClient(chain="base-sepolia")
+        with pytest.raises(ChainTransactionError) as exc_info:
+            client.anchor(swarm_hash=DUMMY_HASH)
+        assert "reverted" in str(exc_info.value).lower()
+
+    def test_gas_limit_multiplier(self, mock_chain_deps):
+        """Tests that gas limit multiplier is applied."""
+        from swarm_provenance_mcp.chain.client import ChainClient
+
+        # Pre-check expects unregistered hash
+        mock_chain_deps[
+            "contract"
+        ].functions.getDataRecord.return_value.call.return_value = (
+            DUMMY_HASH_BYTES,
+            ZERO_ADDRESS,
+            0,
+            "",
+            [],
+            [],
+            0,
+        )
+
+        client = ChainClient(chain="base-sepolia", gas_limit_multiplier=1.5)
+        client.anchor(swarm_hash=DUMMY_HASH)
+
+        # Verify gas was multiplied: 100000 * 1.5 = 150000
+        # Check the tx dict that was passed to sign_transaction
+        call_args = mock_chain_deps["account"].sign_transaction.call_args
+        tx = call_args[0][0]
+        assert tx["gas"] == 150_000
+
+
+class TestChainClientGasLimit:
+    """Tests for explicit gas limit support."""
+
+    def test_explicit_gas_limit_skips_estimation(self, mock_chain_deps):
+        """Tests that explicit gas limit skips estimate_gas call."""
+        from swarm_provenance_mcp.chain.client import ChainClient
+
+        # Pre-check expects unregistered hash
+        mock_chain_deps[
+            "contract"
+        ].functions.getDataRecord.return_value.call.return_value = (
+            DUMMY_HASH_BYTES,
+            ZERO_ADDRESS,
+            0,
+            "",
+            [],
+            [],
+            0,
+        )
+
+        client = ChainClient(chain="base-sepolia", gas_limit=500_000)
+        client.anchor(swarm_hash=DUMMY_HASH)
+
+        # estimate_gas should NOT have been called
+        mock_chain_deps["web3_instance"].eth.estimate_gas.assert_not_called()
+
+        # tx should use explicit gas value
+        call_args = mock_chain_deps["account"].sign_transaction.call_args
+        tx = call_args[0][0]
+        assert tx["gas"] == 500_000
+
+    def test_explicit_gas_limit_no_multiplier(self, mock_chain_deps):
+        """Tests that explicit gas limit ignores multiplier."""
+        from swarm_provenance_mcp.chain.client import ChainClient
+
+        # Pre-check expects unregistered hash
+        mock_chain_deps[
+            "contract"
+        ].functions.getDataRecord.return_value.call.return_value = (
+            DUMMY_HASH_BYTES,
+            ZERO_ADDRESS,
+            0,
+            "",
+            [],
+            [],
+            0,
+        )
+
+        # Even with 2x multiplier, explicit value should be used as-is
+        client = ChainClient(
+            chain="base-sepolia", gas_limit=500_000, gas_limit_multiplier=2.0
+        )
+        client.anchor(swarm_hash=DUMMY_HASH)
+
+        call_args = mock_chain_deps["account"].sign_transaction.call_args
+        tx = call_args[0][0]
+        assert tx["gas"] == 500_000
+
+    def test_gas_limit_none_uses_estimation(self, mock_chain_deps):
+        """Tests that gas_limit=None falls back to estimation."""
+        from swarm_provenance_mcp.chain.client import ChainClient
+
+        # Pre-check expects unregistered hash
+        mock_chain_deps[
+            "contract"
+        ].functions.getDataRecord.return_value.call.return_value = (
+            DUMMY_HASH_BYTES,
+            ZERO_ADDRESS,
+            0,
+            "",
+            [],
+            [],
+            0,
+        )
+
+        client = ChainClient(chain="base-sepolia", gas_limit=None)
+        client.anchor(swarm_hash=DUMMY_HASH)
+
+        # estimate_gas should have been called
+        mock_chain_deps["web3_instance"].eth.estimate_gas.assert_called_once()
+
+
+class TestChainClientProvenanceChain:
+    """Tests for provenance chain traversal."""
+
+    def test_single_record_chain(self, mock_chain_deps):
+        """Tests getting a chain with a single record."""
+        from swarm_provenance_mcp.chain.client import ChainClient
+
+        client = ChainClient(chain="base-sepolia")
+        chain = client.get_provenance_chain(swarm_hash=DUMMY_HASH)
+
+        assert len(chain) == 1
+        assert chain[0].data_hash == DUMMY_HASH
+
+    def test_unregistered_returns_empty(self, mock_chain_deps):
+        """Tests that unregistered hash returns empty chain."""
+        from swarm_provenance_mcp.chain.client import ChainClient
+
+        mock_chain_deps[
+            "contract"
+        ].functions.getDataRecord.return_value.call.return_value = (
+            DUMMY_HASH_BYTES,
+            ZERO_ADDRESS,
+            0,
+            "",
+            [],
+            [],
+            0,
+        )
+
+        client = ChainClient(chain="base-sepolia")
+        chain = client.get_provenance_chain(swarm_hash=DUMMY_HASH)
+
+        assert len(chain) == 0
+
+    def test_chain_with_transformations(self, mock_chain_deps):
+        """Tests chain returns record with transformation descriptions."""
+        from swarm_provenance_mcp.chain.client import ChainClient
+
+        hash_a = DUMMY_HASH
+        hash_a_bytes = bytes.fromhex(hash_a)
+
+        # Contract returns transformations as string[] (descriptions only)
+        mock_chain_deps[
+            "contract"
+        ].functions.getDataRecord.return_value.call.return_value = (
+            hash_a_bytes,
+            DUMMY_ADDRESS,
+            1700000000,
+            "swarm-provenance",
+            ["filtered PII", "anonymized"],
+            [],
+            0,
+        )
+
+        client = ChainClient(chain="base-sepolia")
+        chain = client.get_provenance_chain(swarm_hash=hash_a)
+
+        # Only the queried record is returned (no new_data_hash links to follow)
+        assert len(chain) == 1
+        assert chain[0].data_hash == hash_a
+        assert len(chain[0].transformations) == 2
+        assert chain[0].transformations[0].description == "filtered PII"
+        assert chain[0].transformations[1].description == "anonymized"
+
+    def test_get_provenance_chain_with_depth(self, mock_chain_deps):
+        """Tests that max_depth=0 returns only the root record."""
+        from swarm_provenance_mcp.chain.client import ChainClient
+
+        client = ChainClient(chain="base-sepolia")
+
+        # max_depth=0 should return only the root record
+        chain = client.get_provenance_chain(swarm_hash=DUMMY_HASH, max_depth=0)
+
+        assert len(chain) == 1
+        assert chain[0].data_hash == DUMMY_HASH
+
+    def test_get_provenance_chain_with_depth_zero(self, mock_chain_deps):
+        """Tests that max_depth=0 returns only the root record."""
+        from swarm_provenance_mcp.chain.client import ChainClient
+
+        hash_a = DUMMY_HASH
+        hash_a_bytes = bytes.fromhex(hash_a)
+
+        mock_chain_deps[
+            "contract"
+        ].functions.getDataRecord.return_value.call.return_value = (
+            hash_a_bytes,
+            DUMMY_ADDRESS,
+            1700000000,
+            "swarm-provenance",
+            ["filtered"],
+            [],
+            0,
+        )
+
+        client = ChainClient(chain="base-sepolia")
+        chain = client.get_provenance_chain(swarm_hash=hash_a, max_depth=0)
+
+        assert len(chain) == 1
+        assert chain[0].data_hash == hash_a
+
+    def test_get_provenance_chain_default_cap_at_50(self, mock_chain_deps):
+        """Tests that max_depth=None defaults to 50 (safety cap)."""
+        from swarm_provenance_mcp.chain.client import ChainClient
+
+        hash_a = DUMMY_HASH
+        hash_a_bytes = bytes.fromhex(hash_a)
+
+        # Single record with no transformations - just verify the call works
+        # and that None defaults are handled
+        def mock_get_data_record(data_hash):
+            mock_call = MagicMock()
+            if data_hash == hash_a_bytes:
+                mock_call.call.return_value = (
+                    hash_a_bytes,
+                    DUMMY_ADDRESS,
+                    1700000000,
+                    "swarm-provenance",
+                    [],
+                    [],
+                    0,
+                )
+            else:
+                mock_call.call.return_value = (
+                    data_hash,
+                    ZERO_ADDRESS,
+                    0,
+                    "",
+                    [],
+                    [],
+                    0,
+                )
+            return mock_call
+
+        mock_chain_deps["contract"].functions.getDataRecord = mock_get_data_record
+
+        client = ChainClient(chain="base-sepolia")
+
+        # max_depth=None should use internal cap of 50, not error
+        chain = client.get_provenance_chain(swarm_hash=hash_a, max_depth=None)
+        assert len(chain) == 1
+
+    def test_get_provenance_chain_negative_depth(self, mock_chain_deps):
+        """Tests that negative max_depth returns empty results (no records traversed)."""
+        from swarm_provenance_mcp.chain.client import ChainClient
+
+        hash_a = DUMMY_HASH
+        hash_a_bytes = bytes.fromhex(hash_a)
+
+        def mock_get_data_record(data_hash):
+            mock_call = MagicMock()
+            mock_call.call.return_value = (
+                hash_a_bytes,
+                DUMMY_ADDRESS,
+                1700000000,
+                "swarm-provenance",
+                [],
+                [],
+                0,
+            )
+            return mock_call
+
+        mock_chain_deps["contract"].functions.getDataRecord = mock_get_data_record
+
+        client = ChainClient(chain="base-sepolia")
+
+        # Negative depth: current_depth (0) > effective_max (-1) → skipped
+        chain = client.get_provenance_chain(swarm_hash=hash_a, max_depth=-1)
+        assert len(chain) == 0
+
+
+# --- Models tests ---
+
+
+class TestChainModels:
+    """Tests for chain Pydantic models."""
+
+    def test_data_status_enum_values(self):
+        """Tests DataStatusEnum values."""
+        assert DataStatusEnum.ACTIVE == 0
+        assert DataStatusEnum.RESTRICTED == 1
+        assert DataStatusEnum.DELETED == 2
+
+    def test_anchor_result_serialization(self):
+        """Tests AnchorResult model creation."""
+        result = AnchorResult(
+            tx_hash="0x" + "ab" * 32,
+            block_number=100,
+            gas_used=50000,
+            explorer_url="https://example.com/tx/0xab",
+            swarm_hash=DUMMY_HASH,
+            data_type="test",
+            owner=DUMMY_ADDRESS,
+        )
+        data = result.model_dump()
+        assert data["tx_hash"] == "0x" + "ab" * 32
+        assert data["block_number"] == 100
+
+    def test_chain_provenance_record(self):
+        """Tests ChainProvenanceRecord model."""
+        record = ChainProvenanceRecord(
+            data_hash=DUMMY_HASH,
+            owner=DUMMY_ADDRESS,
+            timestamp=1700000000,
+            data_type="swarm-provenance",
+            status=DataStatusEnum.ACTIVE,
+        )
+        assert record.status == DataStatusEnum.ACTIVE
+        assert record.accessors == []
+        assert record.transformations == []
+
+    def test_chain_wallet_info(self):
+        """Tests ChainWalletInfo model."""
+        info = ChainWalletInfo(
+            address=DUMMY_ADDRESS,
+            balance_wei=1000000000000000000,
+            balance_eth="1.0",
+            chain="base-sepolia",
+            contract_address=DUMMY_CONTRACT,
+        )
+        assert info.balance_wei == 1000000000000000000
+
+
+# --- Exceptions tests ---
+
+
+class TestChainExceptions:
+    """Tests for chain exception hierarchy."""
+
+    def test_chain_error_is_base_exception(self):
+        """Tests that ChainError inherits from Exception."""
+        from swarm_provenance_mcp.chain.exceptions import ChainError
+
+        with pytest.raises(Exception):
+            raise ChainConfigurationError("test")
+
+    def test_chain_connection_error_stores_rpc_url(self):
+        """Tests that ChainConnectionError stores rpc_url."""
+        err = ChainConnectionError("failed", rpc_url="https://rpc.example.com")
+        assert err.rpc_url == "https://rpc.example.com"
+
+    def test_chain_transaction_error_stores_tx_hash(self):
+        """Tests that ChainTransactionError stores tx_hash."""
+        err = ChainTransactionError("reverted", tx_hash="0xabc")
+        assert err.tx_hash == "0xabc"
+
+    def test_data_not_registered_error_stores_hash(self):
+        """Tests that DataNotRegisteredError stores data_hash."""
+        err = DataNotRegisteredError("not found", data_hash=DUMMY_HASH)
+        assert err.data_hash == DUMMY_HASH
+
+
+# --- Transformation parsing tests ---
+
+
+class TestTransformationParsing:
+    """Tests for correct parsing of TransformationRecord structs from getDataRecord."""
+
+    def test_get_with_transformations(self, mock_chain_deps):
+        """Tests that transformations are parsed as (bytes32, string) tuples."""
+        from swarm_provenance_mcp.chain.client import ChainClient
+
+        new_hash_bytes = bytes.fromhex("bb" * 32)
+        # Contract returns transformations as string[] (descriptions only)
+        mock_chain_deps[
+            "contract"
+        ].functions.getDataRecord.return_value.call.return_value = (
+            DUMMY_HASH_BYTES,
+            DUMMY_ADDRESS,
+            1700000000,
+            "swarm-provenance",
+            ["encrypted: AES-256-GCM"],
+            [DUMMY_ADDRESS],
+            0,
+        )
+
+        client = ChainClient(chain="base-sepolia")
+        record = client.get(swarm_hash=DUMMY_HASH)
+
+        assert len(record.transformations) == 1
+        assert record.transformations[0].new_data_hash is None
+        assert record.transformations[0].description == "encrypted: AES-256-GCM"
+
+    def test_get_with_multiple_transformations(self, mock_chain_deps):
+        """Tests parsing multiple transformation records."""
+        from swarm_provenance_mcp.chain.client import ChainClient
+
+        mock_chain_deps[
+            "contract"
+        ].functions.getDataRecord.return_value.call.return_value = (
+            DUMMY_HASH_BYTES,
+            DUMMY_ADDRESS,
+            1700000000,
+            "swarm-provenance",
+            ["filtered PII", "anonymized"],
+            [],
+            0,
+        )
+
+        client = ChainClient(chain="base-sepolia")
+        record = client.get(swarm_hash=DUMMY_HASH)
+
+        assert len(record.transformations) == 2
+        assert record.transformations[0].description == "filtered PII"
+        assert record.transformations[1].description == "anonymized"
+
+    def test_get_with_accessors(self, mock_chain_deps):
+        """Tests that accessors list is parsed correctly."""
+        from swarm_provenance_mcp.chain.client import ChainClient
+
+        accessor_addr = "0x1111111111111111111111111111111111111111"
+        mock_chain_deps[
+            "contract"
+        ].functions.getDataRecord.return_value.call.return_value = (
+            DUMMY_HASH_BYTES,
+            DUMMY_ADDRESS,
+            1700000000,
+            "swarm-provenance",
+            [],
+            [DUMMY_ADDRESS, accessor_addr],
+            0,
+        )
+
+        client = ChainClient(chain="base-sepolia")
+        record = client.get(swarm_hash=DUMMY_HASH)
+
+        assert len(record.accessors) == 2
+        assert accessor_addr in record.accessors
+
+
+# --- Batch status tests ---
+
+
+class TestBatchSetDataStatus:
+    """Tests for batch set data status operations."""
+
+    def test_batch_set_status_mismatched_lengths(self, mock_chain_deps):
+        """Tests that mismatched array lengths raise error."""
+        from swarm_provenance_mcp.chain.contract import DataProvenanceContract
+
+        contract = DataProvenanceContract(
+            web3=mock_chain_deps["web3_instance"],
+            contract_address=DUMMY_CONTRACT,
+        )
+
+        with pytest.raises(ChainValidationError) as exc_info:
+            contract.build_batch_set_data_status_tx(
+                data_hashes=[DUMMY_HASH],
+                statuses=[0, 1],  # mismatched
+                sender=DUMMY_ADDRESS,
+            )
+        assert "same length" in str(exc_info.value)
+
+    def test_batch_set_status_exceeds_limit(self, mock_chain_deps):
+        """Tests that exceeding batch limit raises error."""
+        from swarm_provenance_mcp.chain.contract import (
+            DataProvenanceContract,
+            MAX_BATCH_REGISTER,
+        )
+
+        contract = DataProvenanceContract(
+            web3=mock_chain_deps["web3_instance"],
+            contract_address=DUMMY_CONTRACT,
+        )
+
+        with pytest.raises(ChainValidationError) as exc_info:
+            contract.build_batch_set_data_status_tx(
+                data_hashes=[DUMMY_HASH] * (MAX_BATCH_REGISTER + 1),
+                statuses=[0] * (MAX_BATCH_REGISTER + 1),
+                sender=DUMMY_ADDRESS,
+            )
+        assert "maximum" in str(exc_info.value).lower()
+
+    def test_batch_set_status_client_success(self, mock_chain_deps):
+        """Tests batch_set_status through ChainClient."""
+        from swarm_provenance_mcp.chain.client import ChainClient
+
+        hash2 = "b" * 64
+        client = ChainClient(chain="base-sepolia")
+        result = client.batch_set_status(
+            swarm_hashes=[DUMMY_HASH, hash2],
+            statuses=[1, 2],  # RESTRICTED, DELETED
+        )
+
+        assert isinstance(result, AnchorResult)
+        assert result.swarm_hash == DUMMY_HASH

--- a/tests/test_chain_config.py
+++ b/tests/test_chain_config.py
@@ -1,0 +1,96 @@
+"""Tests for chain configuration fields in Settings."""
+
+import os
+import pytest
+from unittest.mock import patch
+
+
+class TestChainConfig:
+    """Tests for chain-related settings fields."""
+
+    def test_chain_enabled_defaults_false(self):
+        """Tests that chain_enabled defaults to False."""
+        with patch.dict(os.environ, {}, clear=True):
+            from swarm_provenance_mcp.config import Settings
+
+            s = Settings(
+                _env_file=None,
+                swarm_gateway_url="https://example.com",
+            )
+            assert s.chain_enabled is False
+
+    def test_chain_enabled_from_env(self):
+        """Tests that CHAIN_ENABLED env var is loaded."""
+        with patch.dict(os.environ, {"CHAIN_ENABLED": "true"}, clear=True):
+            from swarm_provenance_mcp.config import Settings
+
+            s = Settings(
+                _env_file=None,
+                swarm_gateway_url="https://example.com",
+            )
+            assert s.chain_enabled is True
+
+    def test_chain_name_default(self):
+        """Tests that chain_name defaults to base-sepolia."""
+        with patch.dict(os.environ, {}, clear=True):
+            from swarm_provenance_mcp.config import Settings
+
+            s = Settings(
+                _env_file=None,
+                swarm_gateway_url="https://example.com",
+            )
+            assert s.chain_name == "base-sepolia"
+
+    def test_chain_name_from_env(self):
+        """Tests that CHAIN_NAME env var is loaded."""
+        with patch.dict(os.environ, {"CHAIN_NAME": "base"}, clear=True):
+            from swarm_provenance_mcp.config import Settings
+
+            s = Settings(
+                _env_file=None,
+                swarm_gateway_url="https://example.com",
+            )
+            assert s.chain_name == "base"
+
+    def test_chain_fields_default_none(self):
+        """Tests that optional chain fields default to None."""
+        with patch.dict(os.environ, {}, clear=True):
+            from swarm_provenance_mcp.config import Settings
+
+            s = Settings(
+                _env_file=None,
+                swarm_gateway_url="https://example.com",
+            )
+            assert s.provenance_wallet_key is None
+            assert s.chain_rpc_url is None
+            assert s.chain_contract_address is None
+            assert s.chain_explorer_url is None
+            assert s.chain_gas_limit is None
+
+    def test_chain_gas_limit_parses_as_int(self):
+        """Tests that CHAIN_GAS_LIMIT is parsed as int."""
+        with patch.dict(
+            os.environ, {"CHAIN_GAS_LIMIT": "500000"}, clear=True
+        ):
+            from swarm_provenance_mcp.config import Settings
+
+            s = Settings(
+                _env_file=None,
+                swarm_gateway_url="https://example.com",
+            )
+            assert s.chain_gas_limit == 500000
+            assert isinstance(s.chain_gas_limit, int)
+
+    def test_chain_wallet_key_from_env(self):
+        """Tests that PROVENANCE_WALLET_KEY env var is loaded."""
+        test_key = "0x" + "a" * 64
+        with patch.dict(
+            os.environ, {"PROVENANCE_WALLET_KEY": test_key}, clear=True
+        ):
+            from swarm_provenance_mcp.config import Settings
+
+            s = Settings(
+                _env_file=None,
+                swarm_gateway_url="https://example.com",
+            )
+            assert s.provenance_wallet_key == test_key

--- a/tests/test_chain_import_guard.py
+++ b/tests/test_chain_import_guard.py
@@ -1,0 +1,38 @@
+"""Tests for the chain module import guard mechanism."""
+
+import pytest
+
+
+class TestChainImportGuard:
+    """Tests for CHAIN_AVAILABLE flag and import guard."""
+
+    def test_chain_available_flag_exists(self):
+        """Tests that CHAIN_AVAILABLE flag exists in chain module."""
+        from swarm_provenance_mcp.chain import CHAIN_AVAILABLE
+
+        assert isinstance(CHAIN_AVAILABLE, bool)
+
+    def test_chain_module_loads_without_error(self):
+        """Tests that chain module loads without raising ImportError."""
+        # This should not raise even if web3 is not installed
+        import swarm_provenance_mcp.chain
+
+        assert hasattr(swarm_provenance_mcp.chain, "CHAIN_AVAILABLE")
+
+    def test_chain_available_reflects_web3_presence(self):
+        """Tests that CHAIN_AVAILABLE reflects whether web3 is importable."""
+        from swarm_provenance_mcp.chain import CHAIN_AVAILABLE
+
+        # If web3 is not installed (expected in base test env),
+        # CHAIN_AVAILABLE should be False
+        try:
+            import web3  # noqa: F401
+
+            web3_installed = True
+        except ImportError:
+            web3_installed = False
+
+        # CHAIN_AVAILABLE may differ from web3_installed if eth_account
+        # is also missing, but both False is the common test case
+        if not web3_installed:
+            assert CHAIN_AVAILABLE is False


### PR DESCRIPTION
## Summary

- Port chain module from CLI for on-chain provenance via DataProvenance contract on Base Sepolia
- Add `chain/` subpackage: provider, wallet, contract wrapper, client facade, models, exceptions, ABI
- Add optional `[blockchain]` dependency (web3, eth-account) with import guard
- Add 7 chain config fields to Settings
- Update server with conditional chain initialization and health reporting
- No MCP tools yet — this is the foundation for #49–#56

## Test plan

- [x] 95 new chain tests pass (validation, provider, wallet, client ops, models, exceptions)
- [x] Import guard correctly sets `CHAIN_AVAILABLE=False` without web3
- [x] `chain_enabled` defaults to `False`
- [x] All 254 existing tests still pass
- [x] Black/ruff clean

Closes #48