### PR TITLE
add chain_balance and chain_health MCP tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,8 @@ Optional module for on-chain provenance. Requires `pip install -e .[blockchain]`
 - `get_wallet_info` - Node wallet address and BZZ balance (debug, may be removed)
 - `get_notary_info` - Check notary signing service availability
 - `health_check` - Gateway connectivity status
+- `chain_balance` - On-chain wallet ETH balance with funding guidance (optional, chain enabled)
+- `chain_health` - Blockchain RPC connectivity test (optional, chain enabled)
 
 ### Dependencies Architecture
 - **MCP Framework**: Uses `mcp>=1.0.0` for protocol implementation

--- a/MCP_usage_ecosystem.md
+++ b/MCP_usage_ecosystem.md
@@ -119,6 +119,8 @@ Our Swarm Provenance MCP server currently provides these tools:
 - `get_wallet_info` - Node wallet address and BZZ balance (diagnostic)
 - `get_notary_info` - Check notary signing service availability
 - `health_check` - Verify gateway and network connectivity
+- `chain_balance` - Check on-chain wallet ETH balance with funding guidance *(optional, requires chain enabled)*
+- `chain_health` - Test blockchain RPC connectivity *(optional, requires chain enabled)*
 
 ## 🧭 Agent Workflow Guidance
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This MCP server is specifically designed for provenance data use cases, leveragi
 - **Data Download**: Download data from Swarm network by reference
 - **Provenance Storage**: Store data with provenance metadata for immutable, verifiable records
 - **Health Monitoring**: Check gateway and Swarm network connectivity
+- **Chain Diagnostics** (optional): Check on-chain wallet balance and RPC connectivity for provenance anchoring
 
 ## Installation
 
@@ -114,6 +115,16 @@ Environment variables (set in `.env` file):
 - `DEFAULT_STAMP_AMOUNT`: Default amount for new stamps in wei (default: `2000000000`)
 - `DEFAULT_STAMP_DEPTH`: Default depth for new stamps (default: `17`)
 - `PAYMENT_MODE`: Gateway payment tier (default: `free` — rate limited to 3 write requests/minute)
+
+#### Chain Anchoring (Optional)
+
+- `CHAIN_ENABLED`: Enable on-chain provenance anchoring (default: `false`)
+- `CHAIN_NAME`: Blockchain network — `base-sepolia` (testnet) or `base` (mainnet) (default: `base-sepolia`)
+- `PROVENANCE_WALLET_KEY`: Private key for chain transactions (hex, with or without 0x prefix)
+- `CHAIN_RPC_URL`: Custom RPC endpoint (uses chain preset if not set)
+- `CHAIN_CONTRACT`: Custom DataProvenance contract address (uses chain preset if not set)
+
+When chain is enabled with `pip install -e .[blockchain]`, additional tools (`chain_balance`, `chain_health`) become available for checking wallet balance and RPC connectivity.
 
 ### Gateway Options
 
@@ -299,6 +310,32 @@ Check gateway and Swarm network connectivity status. Returns an adaptive status 
 ```json
 {
   "name": "health_check",
+  "arguments": {}
+}
+```
+
+#### `chain_balance` *(optional — requires `CHAIN_ENABLED=true` and blockchain dependencies)*
+Check the on-chain wallet ETH balance used for provenance anchoring. Returns wallet address, balance, chain info, and actionable funding guidance when balance is low.
+
+**Parameters:** None
+
+**Example:**
+```json
+{
+  "name": "chain_balance",
+  "arguments": {}
+}
+```
+
+#### `chain_health` *(optional — requires `CHAIN_ENABLED=true` and blockchain dependencies)*
+Test blockchain RPC connectivity for on-chain provenance. Returns connection status, chain name, chain ID, latest block number, and RPC response time. Does not require a wallet key.
+
+**Parameters:** None
+
+**Example:**
+```json
+{
+  "name": "chain_health",
   "arguments": {}
 }
 ```

--- a/swarm_provenance_mcp/server.py
+++ b/swarm_provenance_mcp/server.py
@@ -4,7 +4,9 @@ import asyncio
 import json
 import logging
 import re
+import time
 from typing import Any, Dict, List, Optional, Sequence
+from urllib.parse import urlparse
 
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
@@ -99,7 +101,9 @@ ERRORS:
 CHAIN ANCHORING (optional):
 When chain_enabled=true and blockchain dependencies are installed, on-chain provenance tools become available.
 These register Swarm hashes in the DataProvenance smart contract on Base Sepolia, creating an immutable on-chain record.
-Chain tools will be registered as separate tools (anchor_data, verify_chain, etc.) when enabled.
+- chain_health — test RPC connectivity (no wallet needed)
+- chain_balance — check wallet ETH balance with funding guidance when low
+- Additional chain tools (anchor_data, verify_chain, etc.) will be added when enabled.
 The health_check tool reports chain status alongside gateway status.
 
 COMPANION SERVERS:
@@ -134,7 +138,9 @@ def validate_and_clean_stamp_id(stamp_id: str) -> str:
 
     # Validate format
     if not STAMP_ID_PATTERN.match(stamp_id):
-        raise ValueError(f"Invalid stamp ID format. Expected 64-character hexadecimal string (without 0x prefix), got: {stamp_id}")
+        raise ValueError(
+            f"Invalid stamp ID format. Expected 64-character hexadecimal string (without 0x prefix), got: {stamp_id}"
+        )
 
     return stamp_id
 
@@ -160,7 +166,9 @@ def validate_and_clean_reference_hash(reference: str) -> str:
 
     # Validate format
     if not REFERENCE_HASH_PATTERN.match(reference):
-        raise ValueError(f"Invalid reference hash format. Expected 64-character hexadecimal string (without 0x prefix), got: {reference}")
+        raise ValueError(
+            f"Invalid reference hash format. Expected 64-character hexadecimal string (without 0x prefix), got: {reference}"
+        )
 
     return reference
 
@@ -188,7 +196,9 @@ def validate_stamp_depth(depth: int) -> None:
         ValueError: If depth is invalid
     """
     if not (17 <= depth <= 22):
-        raise ValueError(f"Stamp depth must be 17 (small), 20 (medium), or 22 (large), got: {depth}")
+        raise ValueError(
+            f"Stamp depth must be 17 (small), 20 (medium), or 22 (large), got: {depth}"
+        )
 
 
 def validate_data_size(data: str) -> None:
@@ -200,18 +210,29 @@ def validate_data_size(data: str) -> None:
     Raises:
         ValueError: If data size is invalid
     """
-    data_bytes = data.encode('utf-8')
+    data_bytes = data.encode("utf-8")
     if len(data_bytes) > 4096:
-        raise ValueError(f"Data size {len(data_bytes)} bytes exceeds 4KB limit (4096 bytes)")
+        raise ValueError(
+            f"Data size {len(data_bytes)} bytes exceeds 4KB limit (4096 bytes)"
+        )
     if len(data_bytes) == 0:
         raise ValueError("Data cannot be empty")
 
 
 # All tool names for typo correction
 ALL_TOOL_NAMES = [
-    "purchase_stamp", "get_stamp_status", "list_stamps", "extend_stamp",
-    "upload_data", "download_data", "check_stamp_health",
-    "get_wallet_info", "get_notary_info", "health_check"
+    "purchase_stamp",
+    "get_stamp_status",
+    "list_stamps",
+    "extend_stamp",
+    "upload_data",
+    "download_data",
+    "check_stamp_health",
+    "get_wallet_info",
+    "get_notary_info",
+    "health_check",
+    "chain_balance",
+    "chain_health",
 ]
 
 
@@ -259,7 +280,9 @@ def _format_hints(next_tool: str, related: List[str]) -> str:
     return lines
 
 
-def _format_error(message: str, retryable: bool, next_tool: Optional[str] = None) -> str:
+def _format_error(
+    message: str, retryable: bool, next_tool: Optional[str] = None
+) -> str:
     """Format structured error message with retryable flag and recovery hint."""
     lines = message
     lines += f"\n\nretryable: {str(retryable).lower()}"
@@ -271,14 +294,67 @@ def _format_error(message: str, retryable: bool, next_tool: Optional[str] = None
 def _is_retryable_error(e: Exception) -> bool:
     """Determine if an exception represents a transient, retryable error."""
     from requests.exceptions import ConnectionError as ReqConnectionError, Timeout
+
     if isinstance(e, (ReqConnectionError, Timeout)):
         return True
-    if isinstance(e, RequestException) and hasattr(e, 'response') and e.response is not None:
+    if (
+        isinstance(e, RequestException)
+        and hasattr(e, "response")
+        and e.response is not None
+    ):
         return e.response.status_code in (408, 429, 502, 503, 504)
     if isinstance(e, RequestException):
         error_str = str(e).lower()
-        return any(w in error_str for w in ('timeout', 'connection', 'connect'))
+        return any(w in error_str for w in ("timeout", "connection", "connect"))
     return False
+
+
+# Chain balance thresholds and funding URLs
+_MIN_BALANCE_WEI = 10**14  # 0.0001 ETH — cannot reliably transact
+_LOW_BALANCE_WEI = 10**15  # 0.001 ETH — may run out soon
+_FAUCET_URLS = {
+    "base-sepolia": "https://www.alchemy.com/faucets/base-sepolia",
+}
+_BRIDGE_URL = "https://bridge.base.org"
+
+
+def _mask_rpc_url(url: str) -> str:
+    """Extract hostname from RPC URL for display (hide full path/keys)."""
+    try:
+        parsed = urlparse(url)
+        return parsed.hostname or url
+    except Exception:
+        return url
+
+
+def _format_funding_guidance(address: str, balance_wei: int, chain: str) -> str:
+    """Format actionable funding guidance based on wallet balance.
+
+    Returns empty string if balance is healthy, a warning if low,
+    or a critical message with funding instructions if insufficient.
+    """
+    if balance_wei >= _LOW_BALANCE_WEI:
+        return ""
+
+    is_testnet = chain in _FAUCET_URLS
+    balance_eth = balance_wei / 10**18
+
+    if balance_wei < _MIN_BALANCE_WEI:
+        msg = f"\n\n⚠️  CRITICAL: Wallet balance too low for transactions"
+        msg += f"\n   Balance: {balance_eth:.6f} ETH (minimum ~0.0001 ETH needed)"
+        msg += f"\n   Wallet: {address}"
+    else:
+        msg = f"\n\n⚠️  WARNING: Wallet balance is low"
+        msg += f"\n   Balance: {balance_eth:.6f} ETH (may run out soon)"
+        msg += f"\n   Wallet: {address}"
+
+    if is_testnet:
+        faucet_url = _FAUCET_URLS[chain]
+        msg += f"\n   Fund with testnet ETH: {faucet_url}"
+    else:
+        msg += f"\n   Bridge ETH to Base: {_BRIDGE_URL}"
+
+    return msg
 
 
 def create_server() -> Server:
@@ -286,13 +362,13 @@ def create_server() -> Server:
     server = Server(
         settings.mcp_server_name,
         version=settings.mcp_server_version,
-        instructions=MCP_INSTRUCTIONS
+        instructions=MCP_INSTRUCTIONS,
     )
 
     @server.list_tools()
     async def list_tools() -> List[Tool]:
         """List available tools for stamp management."""
-        return [
+        tools = [
             Tool(
                 name="purchase_stamp",
                 description="Purchase a new Swarm postage stamp. Returns a 64-character hex batch ID that can be used with upload_data. A stamp can be reused for multiple uploads until its capacity or TTL is exhausted. After purchase, wait ~1 minute for blockchain propagation before using the stamp.",
@@ -303,23 +379,23 @@ def create_server() -> Server:
                             "type": "integer",
                             "description": f"Amount in wei — controls TTL (time-to-live). Higher amount = longer before the stamp expires (default: {settings.default_stamp_amount})",
                             "default": settings.default_stamp_amount,
-                            "minimum": 1000000
+                            "minimum": 1000000,
                         },
                         "depth": {
                             "type": "integer",
                             "description": f"Depth — controls storage capacity. Three practical sizes: 17 (small, ~35KB), 20 (medium, ~500MB), 22 (large, ~6GB). Capacities are approximate effective volumes with erasure coding. Higher depth costs more (default: {settings.default_stamp_depth})",
                             "default": settings.default_stamp_depth,
                             "minimum": 17,
-                            "maximum": 22
+                            "maximum": 22,
                         },
                         "label": {
                             "type": "string",
                             "description": "Optional human-readable label for easier stamp identification",
-                            "maxLength": 100
-                        }
+                            "maxLength": 100,
+                        },
                     },
-                    "required": []
-                }
+                    "required": [],
+                },
             ),
             Tool(
                 name="get_stamp_status",
@@ -330,20 +406,16 @@ def create_server() -> Server:
                         "stamp_id": {
                             "type": "string",
                             "description": "The 64-character hexadecimal batch ID of the stamp (without 0x prefix). Example: a1b2c3d4e5f6789abcdef0123456789abcdef0123456789abcdef0123456789a",
-                            "pattern": "^[a-fA-F0-9]{64}$"
+                            "pattern": "^[a-fA-F0-9]{64}$",
                         }
                     },
-                    "required": ["stamp_id"]
-                }
+                    "required": ["stamp_id"],
+                },
             ),
             Tool(
                 name="list_stamps",
                 description="List all available postage stamps with their details including batch IDs, amounts, depths, TTL, expiration times, and utilization. Useful for finding a usable stamp for upload_data or identifying stamps that need extending.",
-                inputSchema={
-                    "type": "object",
-                    "properties": {},
-                    "required": []
-                }
+                inputSchema={"type": "object", "properties": {}, "required": []},
             ),
             Tool(
                 name="extend_stamp",
@@ -354,16 +426,16 @@ def create_server() -> Server:
                         "stamp_id": {
                             "type": "string",
                             "description": "The 64-character hexadecimal batch ID of the stamp to extend (without 0x prefix). Example: a1b2c3d4e5f6789abcdef0123456789abcdef0123456789abcdef0123456789a",
-                            "pattern": "^[a-fA-F0-9]{64}$"
+                            "pattern": "^[a-fA-F0-9]{64}$",
                         },
                         "amount": {
                             "type": "integer",
                             "description": "Additional amount to add to the stamp in wei. This will extend the stamp's TTL proportionally.",
-                            "minimum": 1000000
-                        }
+                            "minimum": 1000000,
+                        },
                     },
-                    "required": ["stamp_id", "amount"]
-                }
+                    "required": ["stamp_id", "amount"],
+                },
             ),
             Tool(
                 name="upload_data",
@@ -374,21 +446,21 @@ def create_server() -> Server:
                         "data": {
                             "type": "string",
                             "description": "Data content to upload as a string (max 4096 bytes). Can be JSON, text, or any string data.",
-                            "maxLength": 4096
+                            "maxLength": 4096,
                         },
                         "stamp_id": {
                             "type": "string",
                             "description": "64-character hexadecimal batch ID of the postage stamp (without 0x prefix). Example: a1b2c3d4e5f6789abcdef0123456789abcdef0123456789abcdef0123456789a",
-                            "pattern": "^[a-fA-F0-9]{64}$"
+                            "pattern": "^[a-fA-F0-9]{64}$",
                         },
                         "content_type": {
                             "type": "string",
                             "description": "MIME type of the content (e.g., application/json, text/plain, image/png)",
-                            "default": "application/json"
-                        }
+                            "default": "application/json",
+                        },
                     },
-                    "required": ["data", "stamp_id"]
-                }
+                    "required": ["data", "stamp_id"],
+                },
             ),
             Tool(
                 name="download_data",
@@ -399,11 +471,11 @@ def create_server() -> Server:
                         "reference": {
                             "type": "string",
                             "description": "64-character hexadecimal Swarm reference hash (without 0x prefix). Example: b2c3d4e5f6789abcdef0123456789abcdef0123456789abcdef0123456789ab",
-                            "pattern": "^[a-fA-F0-9]{64}$"
+                            "pattern": "^[a-fA-F0-9]{64}$",
                         }
                     },
-                    "required": ["reference"]
-                }
+                    "required": ["reference"],
+                },
             ),
             Tool(
                 name="check_stamp_health",
@@ -414,40 +486,55 @@ def create_server() -> Server:
                         "stamp_id": {
                             "type": "string",
                             "description": "The 64-character hexadecimal batch ID of the stamp (without 0x prefix)",
-                            "pattern": "^[a-fA-F0-9]{64}$"
+                            "pattern": "^[a-fA-F0-9]{64}$",
                         }
                     },
-                    "required": ["stamp_id"]
-                }
+                    "required": ["stamp_id"],
+                },
             ),
             Tool(
                 name="get_wallet_info",
                 description="Get the gateway node's wallet address and BZZ balance. Useful for checking if the node has sufficient funds to purchase stamps. Note: this is a debugging/diagnostic tool and may be removed in future versions.",
-                inputSchema={
-                    "type": "object",
-                    "properties": {},
-                    "required": []
-                }
+                inputSchema={"type": "object", "properties": {}, "required": []},
             ),
             Tool(
                 name="get_notary_info",
                 description="Check whether the notary signing service is enabled and available on the gateway. When available, uploads can be cryptographically signed for provenance verification.",
-                inputSchema={
-                    "type": "object",
-                    "properties": {},
-                    "required": []
-                }
+                inputSchema={"type": "object", "properties": {}, "required": []},
             ),
             Tool(
                 name="health_check",
                 description="Check gateway and Swarm network connectivity status. Returns gateway URL, response time, and connection status. Call this first to verify the gateway is reachable before purchasing stamps or uploading data.",
-                inputSchema={
-                    "type": "object",
-                    "properties": {},
-                    "required": []
-                }
+                inputSchema={"type": "object", "properties": {}, "required": []},
             ),
         ]
+
+        # Conditionally add chain tools when chain is enabled
+        if CHAIN_AVAILABLE and settings.chain_enabled:
+            tools.extend(
+                [
+                    Tool(
+                        name="chain_balance",
+                        description="Check the on-chain wallet ETH balance used for provenance anchoring transactions. Returns wallet address, balance, chain info, and actionable funding guidance when balance is low. No parameters required.",
+                        inputSchema={
+                            "type": "object",
+                            "properties": {},
+                            "required": [],
+                        },
+                    ),
+                    Tool(
+                        name="chain_health",
+                        description="Test blockchain RPC connectivity for on-chain provenance. Returns connection status, chain name, chain ID, latest block number, RPC response time, and contract address. Does not require a wallet key. Call this to verify chain connectivity before anchoring operations.",
+                        inputSchema={
+                            "type": "object",
+                            "properties": {},
+                            "required": [],
+                        },
+                    ),
+                ]
+            )
+
+        return tools
 
     @server.call_tool()
     async def call_tool(name: str, arguments: Dict[str, Any]) -> CallToolResult:
@@ -473,6 +560,11 @@ def create_server() -> Server:
                 return await handle_get_notary_info(arguments)
             elif name == "health_check":
                 return await handle_health_check(arguments)
+            # Chain tools
+            elif name == "chain_balance":
+                return await handle_chain_balance(arguments)
+            elif name == "chain_health":
+                return await handle_chain_health(arguments)
             # Chain anchoring tools (#49-#56) will be routed here
             else:
                 return CallToolResult(
@@ -480,12 +572,11 @@ def create_server() -> Server:
                         TextContent(
                             type="text",
                             text=_format_error(
-                                _suggest_tool_name(name),
-                                retryable=False
-                            )
+                                _suggest_tool_name(name), retryable=False
+                            ),
                         )
                     ],
-                    isError=True
+                    isError=True,
                 )
         except Exception as e:
             logger.error(f"Error in tool {name}: {e}", exc_info=True)
@@ -497,11 +588,11 @@ def create_server() -> Server:
                         text=_format_error(
                             f"Error executing {name}: {str(e)}",
                             retryable=retryable,
-                            next_tool="health_check"
-                        )
+                            next_tool="health_check",
+                        ),
                     )
                 ],
-                isError=True
+                isError=True,
             )
 
     # --- MCP Prompts (workflow templates for agents) ---
@@ -517,14 +608,14 @@ def create_server() -> Server:
                     PromptArgument(
                         name="data",
                         description="The data content to upload (text, JSON, etc.)",
-                        required=True
+                        required=True,
                     ),
                     PromptArgument(
                         name="content_type",
                         description="MIME type (default: application/json)",
-                        required=False
+                        required=False,
                     ),
-                ]
+                ],
             ),
             Prompt(
                 name="provenance-verify",
@@ -533,19 +624,21 @@ def create_server() -> Server:
                     PromptArgument(
                         name="reference",
                         description="64-character hex Swarm reference hash to verify",
-                        required=True
+                        required=True,
                     ),
-                ]
+                ],
             ),
             Prompt(
                 name="stamp-management",
                 description="Review and manage stamp inventory — list stamps, check health, extend or purchase as needed.",
-                arguments=[]
+                arguments=[],
             ),
         ]
 
     @server.get_prompt()
-    async def get_prompt(name: str, arguments: Optional[Dict[str, str]] = None) -> GetPromptResult:
+    async def get_prompt(
+        name: str, arguments: Optional[Dict[str, str]] = None
+    ) -> GetPromptResult:
         """Return workflow prompt with step-by-step instructions."""
         args = arguments or {}
 
@@ -571,10 +664,10 @@ def create_server() -> Server:
                                 f"4. Call upload_data with the data and stamp_id\n"
                                 f"5. Call download_data with the returned reference to verify the upload\n"
                                 f"6. Report the reference hash — this is the permanent Swarm address"
-                            )
-                        )
+                            ),
+                        ),
                     )
-                ]
+                ],
             )
 
         elif name == "provenance-verify":
@@ -594,10 +687,10 @@ def create_server() -> Server:
                                 f"2. Inspect the returned content — check structure, fields, and integrity\n"
                                 f"3. Report what was found: content type, size, key fields, "
                                 f"and whether the data appears intact"
-                            )
-                        )
+                            ),
+                        ),
                     )
-                ]
+                ],
             )
 
         elif name == "stamp-management":
@@ -619,10 +712,10 @@ def create_server() -> Server:
                                 "   - Stamps with low TTL → extend_stamp to add time\n"
                                 "   - No usable stamps → purchase_stamp\n"
                                 "5. Summarize the inventory status and recommended actions"
-                            )
-                        )
+                            ),
+                        ),
                     )
-                ]
+                ],
             )
 
         else:
@@ -644,25 +737,36 @@ async def handle_purchase_stamp(arguments: Dict[str, Any]) -> CallToolResult:
 
         if label and len(label) > 100:
             return CallToolResult(
-                content=[TextContent(type="text", text=_format_error(
-                    "Error: Label cannot exceed 100 characters",
-                    retryable=False, next_tool="purchase_stamp"
-                ))],
-                isError=True
+                content=[
+                    TextContent(
+                        type="text",
+                        text=_format_error(
+                            "Error: Label cannot exceed 100 characters",
+                            retryable=False,
+                            next_tool="purchase_stamp",
+                        ),
+                    )
+                ],
+                isError=True,
             )
 
         result = gateway_client.purchase_stamp(amount, depth, label)
 
         # Check if purchase was actually successful
-        batch_id = result.get('batchID')
+        batch_id = result.get("batchID")
         if not batch_id:
             error_msg = f"❌ Stamp purchase failed - no stamp ID returned!\n\nGateway response: {result}"
             logger.error(f"Purchase failed - missing batchID in response: {result}")
             return CallToolResult(
-                content=[TextContent(type="text", text=_format_error(
-                    error_msg, retryable=True, next_tool="health_check"
-                ))],
-                isError=True
+                content=[
+                    TextContent(
+                        type="text",
+                        text=_format_error(
+                            error_msg, retryable=True, next_tool="health_check"
+                        ),
+                    )
+                ],
+                isError=True,
             )
 
         response_text = f"🎉 Stamp purchased successfully!\n\n"
@@ -675,29 +779,41 @@ async def handle_purchase_stamp(arguments: Dict[str, Any]) -> CallToolResult:
         response_text += f"\n✅ Stamp ID: `{batch_id}` (immediately available)\n"
         response_text += f"⏱️  IMPORTANT: Wait ~1 minute before using this stamp!\n"
         response_text += f"📋 The stamp info must propagate through the blockchain before it can be used for uploads."
-        response_text += _format_hints("check_stamp_health", ["get_stamp_status", "upload_data", "list_stamps"])
-
-        return CallToolResult(
-            content=[TextContent(type="text", text=response_text)]
+        response_text += _format_hints(
+            "check_stamp_health", ["get_stamp_status", "upload_data", "list_stamps"]
         )
+
+        return CallToolResult(content=[TextContent(type="text", text=response_text)])
 
     except ValueError as e:
         error_msg = f"Validation error: {str(e)}"
         logger.error(error_msg)
         return CallToolResult(
-            content=[TextContent(type="text", text=_format_error(
-                error_msg, retryable=False, next_tool="purchase_stamp"
-            ))],
-            isError=True
+            content=[
+                TextContent(
+                    type="text",
+                    text=_format_error(
+                        error_msg, retryable=False, next_tool="purchase_stamp"
+                    ),
+                )
+            ],
+            isError=True,
         )
     except RequestException as e:
         error_msg = f"Failed to purchase stamp: {str(e)}"
         logger.error(error_msg)
         return CallToolResult(
-            content=[TextContent(type="text", text=_format_error(
-                error_msg, retryable=_is_retryable_error(e), next_tool="health_check"
-            ))],
-            isError=True
+            content=[
+                TextContent(
+                    type="text",
+                    text=_format_error(
+                        error_msg,
+                        retryable=_is_retryable_error(e),
+                        next_tool="health_check",
+                    ),
+                )
+            ],
+            isError=True,
         )
 
 
@@ -720,16 +836,20 @@ async def handle_get_stamp_status(arguments: Dict[str, Any]) -> CallToolResult:
         response_text += f"Block Number: {result.get('blockNumber', 'N/A')}\n"
 
         # Enhanced TTL information
-        batch_ttl = result.get('batchTTL', 'N/A')
-        if batch_ttl != 'N/A':
-            response_text += f"Batch TTL: {batch_ttl:,} seconds ({batch_ttl/86400:.1f} days)\n"
+        batch_ttl = result.get("batchTTL", "N/A")
+        if batch_ttl != "N/A":
+            response_text += (
+                f"Batch TTL: {batch_ttl:,} seconds ({batch_ttl/86400:.1f} days)\n"
+            )
         else:
             response_text += f"Batch TTL: {batch_ttl}\n"
 
-        response_text += f"Expected Expiration: {result.get('expectedExpiration', 'N/A')}\n"
+        response_text += (
+            f"Expected Expiration: {result.get('expectedExpiration', 'N/A')}\n"
+        )
 
         # Enhanced usability information
-        usable = result.get('usable', 'N/A')
+        usable = result.get("usable", "N/A")
         response_text += f"Usable: {usable}"
         if usable is False:
             response_text += " ⚠️  (Cannot be used for uploads)"
@@ -737,8 +857,8 @@ async def handle_get_stamp_status(arguments: Dict[str, Any]) -> CallToolResult:
             response_text += " ✅ (Ready for uploads)"
         response_text += "\n"
 
-        utilization = result.get('utilization', 'N/A')
-        if utilization != 'N/A' and isinstance(utilization, (int, float)):
+        utilization = result.get("utilization", "N/A")
+        if utilization != "N/A" and isinstance(utilization, (int, float)):
             response_text += f"Utilization: {utilization}%\n"
         else:
             response_text += f"Utilization: {utilization}\n"
@@ -746,36 +866,50 @@ async def handle_get_stamp_status(arguments: Dict[str, Any]) -> CallToolResult:
         response_text += f"Immutable: {result.get('immutableFlag', 'N/A')}\n"
         response_text += f"Local: {result.get('local', 'N/A')}\n"
 
-        if result.get('label'):
+        if result.get("label"):
             response_text += f"Label: {result['label']}\n"
 
         # Contextual hints based on usability
         if usable is True:
-            response_text += _format_hints("upload_data", ["extend_stamp", "check_stamp_health"])
+            response_text += _format_hints(
+                "upload_data", ["extend_stamp", "check_stamp_health"]
+            )
         else:
-            response_text += _format_hints("purchase_stamp", ["extend_stamp", "list_stamps"])
+            response_text += _format_hints(
+                "purchase_stamp", ["extend_stamp", "list_stamps"]
+            )
 
-        return CallToolResult(
-            content=[TextContent(type="text", text=response_text)]
-        )
+        return CallToolResult(content=[TextContent(type="text", text=response_text)])
 
     except ValueError as e:
         error_msg = f"Validation error: {str(e)}"
         logger.error(error_msg)
         return CallToolResult(
-            content=[TextContent(type="text", text=_format_error(
-                error_msg, retryable=False, next_tool="list_stamps"
-            ))],
-            isError=True
+            content=[
+                TextContent(
+                    type="text",
+                    text=_format_error(
+                        error_msg, retryable=False, next_tool="list_stamps"
+                    ),
+                )
+            ],
+            isError=True,
         )
     except RequestException as e:
         error_msg = f"Failed to get stamp status: {str(e)}"
         logger.error(error_msg)
         return CallToolResult(
-            content=[TextContent(type="text", text=_format_error(
-                error_msg, retryable=_is_retryable_error(e), next_tool="health_check"
-            ))],
-            isError=True
+            content=[
+                TextContent(
+                    type="text",
+                    text=_format_error(
+                        error_msg,
+                        retryable=_is_retryable_error(e),
+                        next_tool="health_check",
+                    ),
+                )
+            ],
+            isError=True,
         )
 
 
@@ -797,15 +931,17 @@ async def handle_list_stamps(arguments: Dict[str, Any]) -> CallToolResult:
             response_text += f"{'-'*20} | {'-'*20} | {'-'*10}\n"
 
             for stamp in stamps:
-                batch_id = stamp.get('batchID', 'N/A')
-                expiration = stamp.get('expectedExpiration', 'N/A')
-                usable = stamp.get('usable', 'N/A')
+                batch_id = stamp.get("batchID", "N/A")
+                expiration = stamp.get("expectedExpiration", "N/A")
+                usable = stamp.get("usable", "N/A")
 
                 if usable is True:
                     has_usable = True
 
                 # Truncate batch ID for table format
-                display_id = batch_id[:16] + "..." if len(str(batch_id)) > 19 else batch_id
+                display_id = (
+                    batch_id[:16] + "..." if len(str(batch_id)) > 19 else batch_id
+                )
 
                 # Status with emoji
                 if usable is True:
@@ -815,26 +951,35 @@ async def handle_list_stamps(arguments: Dict[str, Any]) -> CallToolResult:
                 else:
                     status = "❓ Unknown"
 
-                response_text += f"{display_id:<20} | {str(expiration):<20} | {status:<10}\n"
+                response_text += (
+                    f"{display_id:<20} | {str(expiration):<20} | {status:<10}\n"
+                )
 
         # Contextual hints
         if has_usable:
-            response_text += _format_hints("upload_data", ["get_stamp_status", "check_stamp_health"])
+            response_text += _format_hints(
+                "upload_data", ["get_stamp_status", "check_stamp_health"]
+            )
         else:
             response_text += _format_hints("purchase_stamp", ["get_wallet_info"])
 
-        return CallToolResult(
-            content=[TextContent(type="text", text=response_text)]
-        )
+        return CallToolResult(content=[TextContent(type="text", text=response_text)])
 
     except RequestException as e:
         error_msg = f"Failed to list stamps: {str(e)}"
         logger.error(error_msg)
         return CallToolResult(
-            content=[TextContent(type="text", text=_format_error(
-                error_msg, retryable=_is_retryable_error(e), next_tool="health_check"
-            ))],
-            isError=True
+            content=[
+                TextContent(
+                    type="text",
+                    text=_format_error(
+                        error_msg,
+                        retryable=_is_retryable_error(e),
+                        next_tool="health_check",
+                    ),
+                )
+            ],
+            isError=True,
         )
 
 
@@ -857,7 +1002,7 @@ async def handle_extend_stamp(arguments: Dict[str, Any]) -> CallToolResult:
 
         response_text = f"✅ Stamp extended successfully!\n\n"
         response_text += f"📋 Extension Details:\n"
-        batch_id = result.get('batchID', 'N/A')
+        batch_id = result.get("batchID", "N/A")
         response_text += f"   Batch ID: `{batch_id}`\n"
         response_text += f"   Additional Amount: {amount:,} wei\n"
         response_text += f"   Status: {result.get('message', 'Extended')}\n\n"
@@ -865,27 +1010,37 @@ async def handle_extend_stamp(arguments: Dict[str, Any]) -> CallToolResult:
         response_text += f"🔍 Check stamp status again in about 1 minute to see the new expiration time."
         response_text += _format_hints("check_stamp_health", ["get_stamp_status"])
 
-        return CallToolResult(
-            content=[TextContent(type="text", text=response_text)]
-        )
+        return CallToolResult(content=[TextContent(type="text", text=response_text)])
 
     except ValueError as e:
         error_msg = f"Validation error: {str(e)}"
         logger.error(error_msg)
         return CallToolResult(
-            content=[TextContent(type="text", text=_format_error(
-                error_msg, retryable=False, next_tool="list_stamps"
-            ))],
-            isError=True
+            content=[
+                TextContent(
+                    type="text",
+                    text=_format_error(
+                        error_msg, retryable=False, next_tool="list_stamps"
+                    ),
+                )
+            ],
+            isError=True,
         )
     except RequestException as e:
         error_msg = f"Failed to extend stamp: {str(e)}"
         logger.error(error_msg)
         return CallToolResult(
-            content=[TextContent(type="text", text=_format_error(
-                error_msg, retryable=_is_retryable_error(e), next_tool="health_check"
-            ))],
-            isError=True
+            content=[
+                TextContent(
+                    type="text",
+                    text=_format_error(
+                        error_msg,
+                        retryable=_is_retryable_error(e),
+                        next_tool="health_check",
+                    ),
+                )
+            ],
+            isError=True,
         )
 
 
@@ -917,20 +1072,23 @@ async def handle_upload_data(arguments: Dict[str, Any]) -> CallToolResult:
             # Verify it's a usable stamp
             if not stamp_details.get("usable", False):
                 return CallToolResult(
-                    content=[TextContent(
-                        type="text",
-                        text=_format_error(
-                            f"Stamp {clean_stamp_id} exists on this gateway but is not usable for uploads. "
-                            f"Please use a different stamp or create a new one.",
-                            retryable=False, next_tool="purchase_stamp"
+                    content=[
+                        TextContent(
+                            type="text",
+                            text=_format_error(
+                                f"Stamp {clean_stamp_id} exists on this gateway but is not usable for uploads. "
+                                f"Please use a different stamp or create a new one.",
+                                retryable=False,
+                                next_tool="purchase_stamp",
+                            ),
                         )
-                    )],
-                    isError=True
+                    ],
+                    isError=True,
                 )
 
         except RequestException as e:
             # If we can't get stamp details, it might be a timing issue with newly purchased stamps
-            if hasattr(e, 'response') and e.response is not None:
+            if hasattr(e, "response") and e.response is not None:
                 if e.response.status_code == 404:
                     # Don't immediately fail - the stamp might be newly purchased
                     # We'll let the upload attempt proceed and let the gateway handle validation
@@ -959,29 +1117,41 @@ async def handle_upload_data(arguments: Dict[str, Any]) -> CallToolResult:
         if stamp_validation_failed:
             response_text += f"\nNote: {validation_error_msg}"
 
-        response_text += _format_hints("download_data", ["upload_data", "check_stamp_health"])
-
-        return CallToolResult(
-            content=[TextContent(type="text", text=response_text)]
+        response_text += _format_hints(
+            "download_data", ["upload_data", "check_stamp_health"]
         )
+
+        return CallToolResult(content=[TextContent(type="text", text=response_text)])
 
     except ValueError as e:
         error_msg = f"Upload validation error: {str(e)}"
         logger.error(error_msg)
         return CallToolResult(
-            content=[TextContent(type="text", text=_format_error(
-                error_msg, retryable=False, next_tool="check_stamp_health"
-            ))],
-            isError=True
+            content=[
+                TextContent(
+                    type="text",
+                    text=_format_error(
+                        error_msg, retryable=False, next_tool="check_stamp_health"
+                    ),
+                )
+            ],
+            isError=True,
         )
     except RequestException as e:
         error_msg = f"Failed to upload data: {str(e)}"
         logger.error(error_msg)
         return CallToolResult(
-            content=[TextContent(type="text", text=_format_error(
-                error_msg, retryable=_is_retryable_error(e), next_tool="health_check"
-            ))],
-            isError=True
+            content=[
+                TextContent(
+                    type="text",
+                    text=_format_error(
+                        error_msg,
+                        retryable=_is_retryable_error(e),
+                        next_tool="health_check",
+                    ),
+                )
+            ],
+            isError=True,
         )
 
 
@@ -999,11 +1169,12 @@ async def handle_download_data(arguments: Dict[str, Any]) -> CallToolResult:
 
         # Try to decode as text, handle JSON appropriately
         try:
-            result_text = result_bytes.decode('utf-8')
+            result_text = result_bytes.decode("utf-8")
 
             # Try to parse as JSON for better presentation
             try:
                 import json
+
                 parsed_json = json.loads(result_text)
 
                 response_text = f"📥 Successfully downloaded JSON data from `{clean_reference}`:\n\n"
@@ -1013,11 +1184,15 @@ async def handle_download_data(arguments: Dict[str, Any]) -> CallToolResult:
                 for key, value in parsed_json.items():
                     if isinstance(value, str) and len(value) > 50:
                         truncated_value = value[:47] + "..."
-                        response_text += f"   {key}: \"{truncated_value}\"\n"
+                        response_text += f'   {key}: "{truncated_value}"\n'
                     elif isinstance(value, dict):
-                        response_text += f"   {key}: {{...}} (object with {len(value)} fields)\n"
+                        response_text += (
+                            f"   {key}: {{...}} (object with {len(value)} fields)\n"
+                        )
                     elif isinstance(value, list):
-                        response_text += f"   {key}: [...] (array with {len(value)} items)\n"
+                        response_text += (
+                            f"   {key}: [...] (array with {len(value)} items)\n"
+                        )
                     else:
                         response_text += f"   {key}: {value}\n"
 
@@ -1029,7 +1204,9 @@ async def handle_download_data(arguments: Dict[str, Any]) -> CallToolResult:
 
         except UnicodeDecodeError:
             # If not valid UTF-8, show as binary data info
-            response_text = f"📥 Successfully downloaded binary data from `{clean_reference}`\n\n"
+            response_text = (
+                f"📥 Successfully downloaded binary data from `{clean_reference}`\n\n"
+            )
             response_text += f"📊 File Information:\n"
             response_text += f"   Size: {len(result_bytes):,} bytes\n"
             response_text += f"   Type: Binary data\n\n"
@@ -1037,27 +1214,32 @@ async def handle_download_data(arguments: Dict[str, Any]) -> CallToolResult:
 
         response_text += _format_hints("upload_data", ["list_stamps"])
 
-        return CallToolResult(
-            content=[TextContent(type="text", text=response_text)]
-        )
+        return CallToolResult(content=[TextContent(type="text", text=response_text)])
 
     except ValueError as e:
         error_msg = f"Validation error: {str(e)}"
         logger.error(error_msg)
         return CallToolResult(
-            content=[TextContent(type="text", text=_format_error(
-                error_msg, retryable=False
-            ))],
-            isError=True
+            content=[
+                TextContent(type="text", text=_format_error(error_msg, retryable=False))
+            ],
+            isError=True,
         )
     except RequestException as e:
         error_msg = f"Failed to download data: {str(e)}"
         logger.error(error_msg)
         return CallToolResult(
-            content=[TextContent(type="text", text=_format_error(
-                error_msg, retryable=_is_retryable_error(e), next_tool="health_check"
-            ))],
-            isError=True
+            content=[
+                TextContent(
+                    type="text",
+                    text=_format_error(
+                        error_msg,
+                        retryable=_is_retryable_error(e),
+                        next_tool="health_check",
+                    ),
+                )
+            ],
+            isError=True,
         )
 
 
@@ -1074,11 +1256,11 @@ async def handle_health_check(arguments: Dict[str, Any]) -> CallToolResult:
     try:
         result = gateway_client.health_check()
 
-        status = result.get('status', 'unknown')
-        gateway_url = result.get('gateway_url', 'N/A')
-        response_time = result.get('response_time_ms', 'N/A')
+        status = result.get("status", "unknown")
+        gateway_url = result.get("gateway_url", "N/A")
+        response_time = result.get("response_time_ms", "N/A")
 
-        gateway_ok = status == 'healthy'
+        gateway_ok = status == "healthy"
 
         if gateway_ok:
             response_text = f"✅ Gateway operational\n\n"
@@ -1091,10 +1273,12 @@ async def handle_health_check(arguments: Dict[str, Any]) -> CallToolResult:
             response_text += f"Gateway: {gateway_url}\n"
             if isinstance(response_time, (int, float)):
                 response_text += f"Response Time: {response_time:.0f}ms\n"
-            recommendations.append("Gateway not healthy — check connectivity or try again later")
+            recommendations.append(
+                "Gateway not healthy — check connectivity or try again later"
+            )
             next_tool = "health_check"
 
-        if result.get('gateway_response'):
+        if result.get("gateway_response"):
             response_text += f"\n📋 Gateway Response: {result['gateway_response']}\n"
 
         # Adaptive: also check stamp availability
@@ -1108,20 +1292,28 @@ async def handle_health_check(arguments: Dict[str, Any]) -> CallToolResult:
                 total_stamps = len(stamps)
                 usable_count = sum(1 for s in stamps if s.get("usable") is True)
 
-                stamps_info += f"\n📋 Stamps: {usable_count} usable / {total_stamps} total\n"
+                stamps_info += (
+                    f"\n📋 Stamps: {usable_count} usable / {total_stamps} total\n"
+                )
 
                 if usable_count > 0:
                     ready = True
                     next_tool = "upload_data"
                 elif total_stamps > 0:
-                    recommendations.append(f"Found {total_stamps} stamp(s) but none are usable — purchase a new one or wait for propagation")
+                    recommendations.append(
+                        f"Found {total_stamps} stamp(s) but none are usable — purchase a new one or wait for propagation"
+                    )
                     next_tool = "purchase_stamp"
                 else:
-                    recommendations.append("No stamps found — purchase one before uploading")
+                    recommendations.append(
+                        "No stamps found — purchase one before uploading"
+                    )
                     next_tool = "purchase_stamp"
             except RequestException:
                 stamps_info += "\n📋 Stamps: unable to check (gateway error)\n"
-                recommendations.append("Could not check stamps — try list_stamps separately")
+                recommendations.append(
+                    "Could not check stamps — try list_stamps separately"
+                )
 
         response_text += stamps_info
 
@@ -1142,11 +1334,19 @@ async def handle_health_check(arguments: Dict[str, Any]) -> CallToolResult:
                     response_text += f"\n   Contract: {chain_client.contract_address}"
                     response_text += f"\n   Wallet: {chain_client.address}"
                 except Exception as chain_err:
-                    response_text += f"\n\n⛓️  Chain: {settings.chain_name} (error: {chain_err})"
-                    recommendations.append("Chain anchoring enabled but RPC unreachable")
+                    response_text += (
+                        f"\n\n⛓️  Chain: {settings.chain_name} (error: {chain_err})"
+                    )
+                    recommendations.append(
+                        "Chain anchoring enabled but RPC unreachable"
+                    )
             else:
-                response_text += f"\n\n⛓️  Chain: enabled but dependencies not installed"
-                recommendations.append("Install blockchain deps: pip install -e .[blockchain]")
+                response_text += (
+                    f"\n\n⛓️  Chain: enabled but dependencies not installed"
+                )
+                recommendations.append(
+                    "Install blockchain deps: pip install -e .[blockchain]"
+                )
 
         # Cross-server coordination info
         response_text += f"\n_companion_servers:"
@@ -1156,9 +1356,7 @@ async def handle_health_check(arguments: Dict[str, Any]) -> CallToolResult:
         response_text += f"\n\n_next: {next_tool}"
         response_text += f"\n_related: list_stamps, purchase_stamp, get_wallet_info"
 
-        return CallToolResult(
-            content=[TextContent(type="text", text=response_text)]
-        )
+        return CallToolResult(content=[TextContent(type="text", text=response_text)])
 
     except RequestException as e:
         gateway_url = settings.swarm_gateway_url
@@ -1172,10 +1370,17 @@ async def handle_health_check(arguments: Dict[str, Any]) -> CallToolResult:
 
         logger.error(f"Health check failed: {str(e)}")
         return CallToolResult(
-            content=[TextContent(type="text", text=_format_error(
-                error_msg, retryable=_is_retryable_error(e), next_tool="health_check"
-            ))],
-            isError=True
+            content=[
+                TextContent(
+                    type="text",
+                    text=_format_error(
+                        error_msg,
+                        retryable=_is_retryable_error(e),
+                        next_tool="health_check",
+                    ),
+                )
+            ],
+            isError=True,
         )
 
 
@@ -1189,64 +1394,85 @@ async def handle_check_stamp_health(arguments: Dict[str, Any]) -> CallToolResult
         clean_stamp_id = validate_and_clean_stamp_id(stamp_id)
         result = gateway_client.check_stamp_health(clean_stamp_id)
 
-        can_upload = result.get('can_upload', False)
-        errors = result.get('errors', [])
-        warnings = result.get('warnings', [])
-        status = result.get('status', {})
+        can_upload = result.get("can_upload", False)
+        errors = result.get("errors", [])
+        warnings = result.get("warnings", [])
+        status = result.get("status", {})
 
         if can_upload:
             response_text = f"✅ Stamp {clean_stamp_id[:16]}... is healthy and ready for uploads.\n\n"
         else:
-            response_text = f"❌ Stamp {clean_stamp_id[:16]}... cannot be used for uploads.\n\n"
+            response_text = (
+                f"❌ Stamp {clean_stamp_id[:16]}... cannot be used for uploads.\n\n"
+            )
 
         if errors:
             response_text += "Errors:\n"
             for err in errors:
-                response_text += f"   [{err.get('code', '?')}] {err.get('message', '')}\n"
-                if err.get('suggestion'):
+                response_text += (
+                    f"   [{err.get('code', '?')}] {err.get('message', '')}\n"
+                )
+                if err.get("suggestion"):
                     response_text += f"   → {err['suggestion']}\n"
 
         if warnings:
             response_text += "Warnings:\n"
             for warn in warnings:
-                response_text += f"   [{warn.get('code', '?')}] {warn.get('message', '')}\n"
-                if warn.get('suggestion'):
+                response_text += (
+                    f"   [{warn.get('code', '?')}] {warn.get('message', '')}\n"
+                )
+                if warn.get("suggestion"):
                     response_text += f"   → {warn['suggestion']}\n"
 
         if status:
             response_text += f"\nStatus:\n"
-            if status.get('utilizationPercent') is not None:
+            if status.get("utilizationPercent") is not None:
                 response_text += f"   Utilization: {status['utilizationPercent']}% ({status.get('utilizationStatus', 'unknown')})\n"
-            if status.get('batchTTL') is not None:
-                ttl = status['batchTTL']
+            if status.get("batchTTL") is not None:
+                ttl = status["batchTTL"]
                 response_text += f"   TTL: {ttl:,} seconds ({ttl/86400:.1f} days)\n"
-            if status.get('expectedExpiration'):
+            if status.get("expectedExpiration"):
                 response_text += f"   Expires: {status['expectedExpiration']}\n"
 
         # Contextual hints based on health
         if can_upload:
-            response_text += _format_hints("upload_data", ["get_stamp_status", "extend_stamp"])
+            response_text += _format_hints(
+                "upload_data", ["get_stamp_status", "extend_stamp"]
+            )
         else:
-            response_text += _format_hints("purchase_stamp", ["list_stamps", "extend_stamp"])
+            response_text += _format_hints(
+                "purchase_stamp", ["list_stamps", "extend_stamp"]
+            )
 
-        return CallToolResult(
-            content=[TextContent(type="text", text=response_text)]
-        )
+        return CallToolResult(content=[TextContent(type="text", text=response_text)])
 
     except ValueError as e:
         return CallToolResult(
-            content=[TextContent(type="text", text=_format_error(
-                f"Validation error: {str(e)}", retryable=False, next_tool="list_stamps"
-            ))],
-            isError=True
+            content=[
+                TextContent(
+                    type="text",
+                    text=_format_error(
+                        f"Validation error: {str(e)}",
+                        retryable=False,
+                        next_tool="list_stamps",
+                    ),
+                )
+            ],
+            isError=True,
         )
     except RequestException as e:
         return CallToolResult(
-            content=[TextContent(type="text", text=_format_error(
-                f"Failed to check stamp health: {str(e)}",
-                retryable=_is_retryable_error(e), next_tool="health_check"
-            ))],
-            isError=True
+            content=[
+                TextContent(
+                    type="text",
+                    text=_format_error(
+                        f"Failed to check stamp health: {str(e)}",
+                        retryable=_is_retryable_error(e),
+                        next_tool="health_check",
+                    ),
+                )
+            ],
+            isError=True,
         )
 
 
@@ -1260,17 +1486,161 @@ async def handle_get_wallet_info(arguments: Dict[str, Any]) -> CallToolResult:
         response_text += f"   BZZ Balance: {result.get('bzzBalance', 'N/A')}\n"
         response_text += _format_hints("purchase_stamp", ["list_stamps"])
 
-        return CallToolResult(
-            content=[TextContent(type="text", text=response_text)]
-        )
+        return CallToolResult(content=[TextContent(type="text", text=response_text)])
 
     except RequestException as e:
         return CallToolResult(
-            content=[TextContent(type="text", text=_format_error(
-                f"Failed to get wallet info: {str(e)}",
-                retryable=_is_retryable_error(e), next_tool="health_check"
-            ))],
-            isError=True
+            content=[
+                TextContent(
+                    type="text",
+                    text=_format_error(
+                        f"Failed to get wallet info: {str(e)}",
+                        retryable=_is_retryable_error(e),
+                        next_tool="health_check",
+                    ),
+                )
+            ],
+            isError=True,
+        )
+
+
+async def handle_chain_balance(arguments: Dict[str, Any]) -> CallToolResult:
+    """Handle chain wallet balance requests."""
+    if not CHAIN_AVAILABLE:
+        return CallToolResult(
+            content=[
+                TextContent(
+                    type="text",
+                    text=_format_error(
+                        "Chain module not available. Install blockchain dependencies: pip install -e .[blockchain]",
+                        retryable=False,
+                    ),
+                )
+            ],
+            isError=True,
+        )
+    if not chain_client:
+        return CallToolResult(
+            content=[
+                TextContent(
+                    type="text",
+                    text=_format_error(
+                        "Chain client not initialized. Set PROVENANCE_WALLET_KEY to enable wallet operations.",
+                        retryable=False,
+                        next_tool="chain_health",
+                    ),
+                )
+            ],
+            isError=True,
+        )
+
+    try:
+        wallet_info = chain_client.balance()
+
+        response_text = f"⛓️  Chain Wallet Balance\n\n"
+        response_text += f"   Wallet: {wallet_info.address}\n"
+        response_text += f"   Balance: {wallet_info.balance_eth} ETH ({wallet_info.balance_wei:,} wei)\n"
+        response_text += f"   Chain: {wallet_info.chain}\n"
+        response_text += f"   Contract: {wallet_info.contract_address}\n"
+        response_text += f"   RPC: {_mask_rpc_url(chain_client._provider.rpc_url)}"
+
+        guidance = _format_funding_guidance(
+            wallet_info.address, wallet_info.balance_wei, wallet_info.chain
+        )
+        response_text += guidance
+        response_text += _format_hints("anchor_hash", ["chain_health", "health_check"])
+
+        return CallToolResult(content=[TextContent(type="text", text=response_text)])
+
+    except Exception as e:
+        return CallToolResult(
+            content=[
+                TextContent(
+                    type="text",
+                    text=_format_error(
+                        f"Failed to get chain balance: {str(e)}",
+                        retryable=True,
+                        next_tool="chain_health",
+                    ),
+                )
+            ],
+            isError=True,
+        )
+
+
+async def handle_chain_health(arguments: Dict[str, Any]) -> CallToolResult:
+    """Handle chain RPC health check requests."""
+    if not CHAIN_AVAILABLE:
+        return CallToolResult(
+            content=[
+                TextContent(
+                    type="text",
+                    text=_format_error(
+                        "Chain module not available. Install blockchain dependencies: pip install -e .[blockchain]",
+                        retryable=False,
+                    ),
+                )
+            ],
+            isError=True,
+        )
+
+    try:
+        # Use chain_client if available, otherwise create a temporary provider
+        if chain_client:
+            provider = chain_client._provider
+        else:
+            from .chain.provider import ChainProvider
+
+            provider = ChainProvider(
+                chain=settings.chain_name,
+                rpc_url=settings.chain_rpc_url,
+                contract_address=settings.chain_contract_address,
+                explorer_url=settings.chain_explorer_url,
+            )
+
+        start = time.monotonic()
+        provider.health_check()
+        elapsed_ms = (time.monotonic() - start) * 1000
+
+        block_number = provider.get_block_number()
+
+        response_text = f"⛓️  Chain RPC Health\n\n"
+        response_text += f"   Connected: true\n"
+        response_text += f"   Chain: {provider.chain}\n"
+        response_text += f"   Chain ID: {provider.chain_id}\n"
+        response_text += f"   Latest Block: {block_number:,}\n"
+        response_text += f"   RPC Response: {elapsed_ms:.0f}ms\n"
+        response_text += f"   Contract: {provider.contract_address}\n"
+        response_text += f"   RPC: {_mask_rpc_url(provider.rpc_url)}"
+        response_text += _format_hints("chain_balance", ["health_check"])
+
+        return CallToolResult(content=[TextContent(type="text", text=response_text)])
+
+    except Exception as e:
+        # Import ChainConnectionError for better error detection
+        try:
+            from .chain.exceptions import ChainConnectionError
+
+            is_connection_error = isinstance(e, ChainConnectionError)
+        except ImportError:
+            is_connection_error = False
+
+        error_msg = f"⛓️  Chain RPC Health\n\n"
+        error_msg += f"   Connected: false\n"
+        error_msg += f"   Error: {str(e)}"
+
+        return CallToolResult(
+            content=[
+                TextContent(
+                    type="text",
+                    text=_format_error(
+                        error_msg,
+                        retryable=is_connection_error,
+                        next_tool="health_check",
+                    ),
+                )
+            ],
+            isError=True,
         )
 
 
@@ -1279,31 +1649,37 @@ async def handle_get_notary_info(arguments: Dict[str, Any]) -> CallToolResult:
     try:
         result = gateway_client.get_notary_info()
 
-        enabled = result.get('enabled', False)
-        available = result.get('available', False)
+        enabled = result.get("enabled", False)
+        available = result.get("available", False)
 
         if enabled and available:
             response_text = f"✅ Notary service is enabled and available.\n\n"
             response_text += f"   Address: {result.get('address', 'N/A')}\n"
         elif enabled and not available:
-            response_text = f"⚠️  Notary service is enabled but not currently available.\n\n"
+            response_text = (
+                f"⚠️  Notary service is enabled but not currently available.\n\n"
+            )
         else:
             response_text = f"Notary service is not enabled on this gateway.\n\n"
 
         response_text += f"   Status: {result.get('message', 'N/A')}\n"
         response_text += _format_hints("upload_data", ["health_check"])
 
-        return CallToolResult(
-            content=[TextContent(type="text", text=response_text)]
-        )
+        return CallToolResult(content=[TextContent(type="text", text=response_text)])
 
     except RequestException as e:
         return CallToolResult(
-            content=[TextContent(type="text", text=_format_error(
-                f"Failed to get notary info: {str(e)}",
-                retryable=_is_retryable_error(e), next_tool="health_check"
-            ))],
-            isError=True
+            content=[
+                TextContent(
+                    type="text",
+                    text=_format_error(
+                        f"Failed to get notary info: {str(e)}",
+                        retryable=_is_retryable_error(e),
+                        next_tool="health_check",
+                    ),
+                )
+            ],
+            isError=True,
         )
 
 
@@ -1318,12 +1694,12 @@ async def main():
 
     try:
         async with stdio_server() as (read_stream, write_stream):
-            logger.info(f"Starting {settings.mcp_server_name} v{settings.mcp_server_version}")
+            logger.info(
+                f"Starting {settings.mcp_server_name} v{settings.mcp_server_version}"
+            )
             logger.info(f"Gateway URL: {settings.swarm_gateway_url}")
             await server.run(
-                read_stream,
-                write_stream,
-                server.create_initialization_options()
+                read_stream, write_stream, server.create_initialization_options()
             )
     except KeyboardInterrupt:
         logger.info("Received interrupt signal")

--- a/tests/test_tool_execution.py
+++ b/tests/test_tool_execution.py
@@ -23,7 +23,7 @@ async def call_tool_directly(server, name: str, arguments: Dict[str, Any]):
         handle_purchase_stamp, handle_get_stamp_status, handle_list_stamps,
         handle_extend_stamp, handle_upload_data, handle_download_data,
         handle_check_stamp_health, handle_get_wallet_info, handle_get_notary_info,
-        handle_health_check
+        handle_health_check, handle_chain_balance, handle_chain_health
     )
 
     handlers = {
@@ -36,7 +36,9 @@ async def call_tool_directly(server, name: str, arguments: Dict[str, Any]):
         "check_stamp_health": handle_check_stamp_health,
         "get_wallet_info": handle_get_wallet_info,
         "get_notary_info": handle_get_notary_info,
-        "health_check": handle_health_check
+        "health_check": handle_health_check,
+        "chain_balance": handle_chain_balance,
+        "chain_health": handle_chain_health,
     }
 
     try:
@@ -884,3 +886,362 @@ class TestToolParameterValidation:
             if result.isError:
                 error_text = result.content[0].text.lower()
                 assert "stamp_id" in error_text or "empty" in error_text or "required" in error_text
+
+
+class TestChainBalance:
+    """Test chain_balance tool execution."""
+
+    @pytest.fixture
+    def server(self):
+        return create_server()
+
+    def _mock_wallet_info(self, balance_wei=10**17, chain="base-sepolia"):
+        """Create a mock ChainWalletInfo."""
+        mock_info = MagicMock()
+        mock_info.address = "0x1234567890abcdef1234567890abcdef12345678"
+        mock_info.balance_wei = balance_wei
+        mock_info.balance_eth = f"{balance_wei / 10**18:.6f}"
+        mock_info.chain = chain
+        mock_info.contract_address = "0x9a3c6F47B69211F05891CCb7aD33596290b9fE64"
+        return mock_info
+
+    async def test_chain_balance_funded(self, server):
+        """Healthy balance should show wallet info without warnings."""
+        mock_client = MagicMock()
+        mock_client.balance.return_value = self._mock_wallet_info(balance_wei=10**17)
+        mock_client._provider = MagicMock()
+        mock_client._provider.rpc_url = "https://sepolia.base.org"
+
+        with patch('swarm_provenance_mcp.server.CHAIN_AVAILABLE', True), \
+             patch('swarm_provenance_mcp.server.chain_client', mock_client):
+            result = await call_tool_directly(server, "chain_balance", {})
+
+        assert not result.isError
+        text = result.content[0].text
+        assert "0x1234" in text
+        assert "ETH" in text
+        assert "base-sepolia" in text
+        assert "CRITICAL" not in text
+        assert "WARNING" not in text
+
+    async def test_chain_balance_low(self, server):
+        """Balance below LOW threshold should show warning."""
+        mock_client = MagicMock()
+        mock_client.balance.return_value = self._mock_wallet_info(balance_wei=5 * 10**14)
+        mock_client._provider = MagicMock()
+        mock_client._provider.rpc_url = "https://sepolia.base.org"
+
+        with patch('swarm_provenance_mcp.server.CHAIN_AVAILABLE', True), \
+             patch('swarm_provenance_mcp.server.chain_client', mock_client):
+            result = await call_tool_directly(server, "chain_balance", {})
+
+        assert not result.isError
+        text = result.content[0].text
+        assert "WARNING" in text
+        assert "low" in text.lower()
+
+    async def test_chain_balance_insufficient(self, server):
+        """Balance below MIN threshold should show critical message with faucet."""
+        mock_client = MagicMock()
+        mock_client.balance.return_value = self._mock_wallet_info(balance_wei=10**12)
+        mock_client._provider = MagicMock()
+        mock_client._provider.rpc_url = "https://sepolia.base.org"
+
+        with patch('swarm_provenance_mcp.server.CHAIN_AVAILABLE', True), \
+             patch('swarm_provenance_mcp.server.chain_client', mock_client):
+            result = await call_tool_directly(server, "chain_balance", {})
+
+        assert not result.isError
+        text = result.content[0].text
+        assert "CRITICAL" in text
+        assert "faucet" in text.lower() or "alchemy" in text.lower()
+
+    async def test_chain_balance_mainnet(self, server):
+        """Mainnet chain should show bridge URL instead of faucet."""
+        mock_client = MagicMock()
+        mock_client.balance.return_value = self._mock_wallet_info(
+            balance_wei=10**12, chain="base"
+        )
+        mock_client._provider = MagicMock()
+        mock_client._provider.rpc_url = "https://mainnet.base.org"
+
+        with patch('swarm_provenance_mcp.server.CHAIN_AVAILABLE', True), \
+             patch('swarm_provenance_mcp.server.chain_client', mock_client):
+            result = await call_tool_directly(server, "chain_balance", {})
+
+        assert not result.isError
+        text = result.content[0].text
+        assert "bridge.base.org" in text
+
+    async def test_chain_balance_not_available(self, server):
+        """CHAIN_AVAILABLE=False should return error."""
+        with patch('swarm_provenance_mcp.server.CHAIN_AVAILABLE', False):
+            result = await call_tool_directly(server, "chain_balance", {})
+
+        assert result.isError
+        text = result.content[0].text
+        assert "not available" in text.lower() or "not installed" in text.lower()
+
+    async def test_chain_balance_no_client(self, server):
+        """chain_client=None should return error suggesting chain_health."""
+        with patch('swarm_provenance_mcp.server.CHAIN_AVAILABLE', True), \
+             patch('swarm_provenance_mcp.server.chain_client', None):
+            result = await call_tool_directly(server, "chain_balance", {})
+
+        assert result.isError
+        text = result.content[0].text
+        assert "wallet" in text.lower() or "PROVENANCE_WALLET_KEY" in text
+
+    async def test_chain_balance_hints(self, server):
+        """Response should include _next and _related hints."""
+        mock_client = MagicMock()
+        mock_client.balance.return_value = self._mock_wallet_info()
+        mock_client._provider = MagicMock()
+        mock_client._provider.rpc_url = "https://sepolia.base.org"
+
+        with patch('swarm_provenance_mcp.server.CHAIN_AVAILABLE', True), \
+             patch('swarm_provenance_mcp.server.chain_client', mock_client):
+            result = await call_tool_directly(server, "chain_balance", {})
+
+        text = result.content[0].text
+        assert "_next:" in text
+        assert "_related:" in text
+
+    async def test_chain_tools_registered_when_enabled(self, server):
+        """Chain tools should appear in list_tools when chain is enabled."""
+        from mcp.types import ListToolsRequest
+
+        with patch('swarm_provenance_mcp.server.CHAIN_AVAILABLE', True), \
+             patch('swarm_provenance_mcp.server.settings') as mock_settings:
+            mock_settings.chain_enabled = True
+            mock_settings.mcp_server_name = "test"
+            mock_settings.mcp_server_version = "0.1.0"
+            mock_settings.default_stamp_amount = 2000000000
+            mock_settings.default_stamp_depth = 17
+
+            test_server = create_server()
+            # Find the list_tools handler
+            handler = None
+            for h in test_server.request_handlers.values():
+                if hasattr(h, '__name__') and 'list_tools' in str(h):
+                    handler = h
+                    break
+            assert handler is not None
+            result = await handler(ListToolsRequest(method="tools/list"))
+            inner = result.root if hasattr(result, 'root') else result
+            tools = inner.tools if hasattr(inner, 'tools') else inner
+            tool_names = {t.name for t in tools}
+            assert "chain_balance" in tool_names
+            assert "chain_health" in tool_names
+
+
+class TestChainHealth:
+    """Test chain_health tool execution."""
+
+    @pytest.fixture
+    def server(self):
+        return create_server()
+
+    async def test_chain_health_connected(self, server):
+        """Successful health check should show connection info."""
+        mock_client = MagicMock()
+        mock_client._provider = MagicMock()
+        mock_client._provider.chain = "base-sepolia"
+        mock_client._provider.chain_id = 84532
+        mock_client._provider.rpc_url = "https://sepolia.base.org"
+        mock_client._provider.contract_address = "0x9a3c6F47B69211F05891CCb7aD33596290b9fE64"
+        mock_client._provider.health_check.return_value = True
+        mock_client._provider.get_block_number.return_value = 12345678
+
+        with patch('swarm_provenance_mcp.server.CHAIN_AVAILABLE', True), \
+             patch('swarm_provenance_mcp.server.chain_client', mock_client):
+            result = await call_tool_directly(server, "chain_health", {})
+
+        assert not result.isError
+        text = result.content[0].text
+        assert "Connected: true" in text
+        assert "base-sepolia" in text
+        assert "84532" in text
+        assert "12,345,678" in text
+
+    async def test_chain_health_disconnected(self, server):
+        """Connection error should show disconnected status."""
+        mock_client = MagicMock()
+        mock_client._provider = MagicMock()
+        mock_client._provider.health_check.side_effect = Exception("Connection refused")
+
+        with patch('swarm_provenance_mcp.server.CHAIN_AVAILABLE', True), \
+             patch('swarm_provenance_mcp.server.chain_client', mock_client):
+            result = await call_tool_directly(server, "chain_health", {})
+
+        assert result.isError
+        text = result.content[0].text
+        assert "Connected: false" in text
+
+    async def test_chain_health_not_available(self, server):
+        """CHAIN_AVAILABLE=False should return error."""
+        with patch('swarm_provenance_mcp.server.CHAIN_AVAILABLE', False):
+            result = await call_tool_directly(server, "chain_health", {})
+
+        assert result.isError
+        text = result.content[0].text
+        assert "not available" in text.lower() or "not installed" in text.lower()
+
+    async def test_chain_health_no_wallet(self, server):
+        """chain_client=None should still work by creating a temporary provider."""
+        mock_provider = MagicMock()
+        mock_provider.chain = "base-sepolia"
+        mock_provider.chain_id = 84532
+        mock_provider.rpc_url = "https://sepolia.base.org"
+        mock_provider.contract_address = "0x9a3c6F47B69211F05891CCb7aD33596290b9fE64"
+        mock_provider.health_check.return_value = True
+        mock_provider.get_block_number.return_value = 99999
+
+        with patch('swarm_provenance_mcp.server.CHAIN_AVAILABLE', True), \
+             patch('swarm_provenance_mcp.server.chain_client', None), \
+             patch('swarm_provenance_mcp.chain.provider.ChainProvider', return_value=mock_provider):
+            result = await call_tool_directly(server, "chain_health", {})
+
+        assert not result.isError
+        text = result.content[0].text
+        assert "Connected: true" in text
+
+    async def test_chain_health_hints(self, server):
+        """Response should include _next and _related hints."""
+        mock_client = MagicMock()
+        mock_client._provider = MagicMock()
+        mock_client._provider.chain = "base-sepolia"
+        mock_client._provider.chain_id = 84532
+        mock_client._provider.rpc_url = "https://sepolia.base.org"
+        mock_client._provider.contract_address = "0x9a3c"
+        mock_client._provider.health_check.return_value = True
+        mock_client._provider.get_block_number.return_value = 100
+
+        with patch('swarm_provenance_mcp.server.CHAIN_AVAILABLE', True), \
+             patch('swarm_provenance_mcp.server.chain_client', mock_client):
+            result = await call_tool_directly(server, "chain_health", {})
+
+        text = result.content[0].text
+        assert "_next: chain_balance" in text
+        assert "_related:" in text
+
+    async def test_chain_health_rpc_masked(self, server):
+        """RPC URL should show only hostname, not full URL."""
+        mock_client = MagicMock()
+        mock_client._provider = MagicMock()
+        mock_client._provider.chain = "base-sepolia"
+        mock_client._provider.chain_id = 84532
+        mock_client._provider.rpc_url = "https://my-secret-rpc.example.com/v1/key123"
+        mock_client._provider.contract_address = "0x9a3c"
+        mock_client._provider.health_check.return_value = True
+        mock_client._provider.get_block_number.return_value = 100
+
+        with patch('swarm_provenance_mcp.server.CHAIN_AVAILABLE', True), \
+             patch('swarm_provenance_mcp.server.chain_client', mock_client):
+            result = await call_tool_directly(server, "chain_health", {})
+
+        text = result.content[0].text
+        assert "my-secret-rpc.example.com" in text
+        assert "key123" not in text
+
+    async def test_chain_health_provider_creation_fails(self, server):
+        """Failing to create temp provider (e.g. missing contract) should return error."""
+        with patch('swarm_provenance_mcp.server.CHAIN_AVAILABLE', True), \
+             patch('swarm_provenance_mcp.server.chain_client', None), \
+             patch('swarm_provenance_mcp.server.settings') as mock_settings:
+            mock_settings.chain_name = "base"
+            mock_settings.chain_rpc_url = None
+            mock_settings.chain_contract_address = None
+            mock_settings.chain_explorer_url = None
+            # ChainProvider will raise because base has no contract preset
+            result = await call_tool_directly(server, "chain_health", {})
+
+        assert result.isError
+        text = result.content[0].text
+        assert "Connected: false" in text
+
+
+class TestFundingGuidance:
+    """Direct unit tests for _format_funding_guidance helper."""
+
+    def test_healthy_balance_returns_empty(self):
+        """Balance above LOW threshold should return empty string."""
+        from swarm_provenance_mcp.server import _format_funding_guidance, _LOW_BALANCE_WEI
+        result = _format_funding_guidance("0xabc", _LOW_BALANCE_WEI, "base-sepolia")
+        assert result == ""
+
+    def test_well_above_threshold_returns_empty(self):
+        """Large balance should return empty string."""
+        from swarm_provenance_mcp.server import _format_funding_guidance
+        result = _format_funding_guidance("0xabc", 10**18, "base-sepolia")
+        assert result == ""
+
+    def test_low_balance_returns_warning(self):
+        """Balance between MIN and LOW should return WARNING."""
+        from swarm_provenance_mcp.server import (
+            _format_funding_guidance, _MIN_BALANCE_WEI, _LOW_BALANCE_WEI,
+        )
+        balance = (_MIN_BALANCE_WEI + _LOW_BALANCE_WEI) // 2
+        result = _format_funding_guidance("0xabc", balance, "base-sepolia")
+        assert "WARNING" in result
+        assert "CRITICAL" not in result
+        assert "0xabc" in result
+
+    def test_insufficient_balance_returns_critical(self):
+        """Balance below MIN should return CRITICAL."""
+        from swarm_provenance_mcp.server import _format_funding_guidance
+        result = _format_funding_guidance("0xabc", 100, "base-sepolia")
+        assert "CRITICAL" in result
+        assert "0xabc" in result
+
+    def test_zero_balance_returns_critical(self):
+        """Zero balance should return CRITICAL."""
+        from swarm_provenance_mcp.server import _format_funding_guidance
+        result = _format_funding_guidance("0xabc", 0, "base-sepolia")
+        assert "CRITICAL" in result
+
+    def test_testnet_shows_faucet(self):
+        """Testnet chain should include faucet URL."""
+        from swarm_provenance_mcp.server import _format_funding_guidance
+        result = _format_funding_guidance("0xabc", 100, "base-sepolia")
+        assert "faucet" in result.lower() or "alchemy" in result.lower()
+
+    def test_mainnet_shows_bridge(self):
+        """Mainnet chain should include bridge URL."""
+        from swarm_provenance_mcp.server import _format_funding_guidance
+        result = _format_funding_guidance("0xabc", 100, "base")
+        assert "bridge.base.org" in result
+
+    def test_unknown_chain_shows_bridge(self):
+        """Unknown chain (not in faucet list) should show bridge URL."""
+        from swarm_provenance_mcp.server import _format_funding_guidance
+        result = _format_funding_guidance("0xabc", 100, "base-mainnet-custom")
+        assert "bridge.base.org" in result
+
+
+class TestMaskRpcUrl:
+    """Direct unit tests for _mask_rpc_url helper."""
+
+    def test_standard_url(self):
+        from swarm_provenance_mcp.server import _mask_rpc_url
+        assert _mask_rpc_url("https://sepolia.base.org") == "sepolia.base.org"
+
+    def test_url_with_path_and_key(self):
+        from swarm_provenance_mcp.server import _mask_rpc_url
+        result = _mask_rpc_url("https://rpc.example.com/v1/secret-key-123")
+        assert result == "rpc.example.com"
+
+    def test_url_with_port(self):
+        from swarm_provenance_mcp.server import _mask_rpc_url
+        result = _mask_rpc_url("http://localhost:8545")
+        assert result == "localhost"
+
+    def test_empty_string(self):
+        from swarm_provenance_mcp.server import _mask_rpc_url
+        result = _mask_rpc_url("")
+        assert isinstance(result, str)
+
+    def test_garbage_input(self):
+        from swarm_provenance_mcp.server import _mask_rpc_url
+        result = _mask_rpc_url("not-a-url")
+        assert isinstance(result, str)


### PR DESCRIPTION
## Summary

Closes #54

- **`chain_balance`** — check wallet ETH balance with actionable funding guidance (faucet for testnet, bridge for mainnet) when balance is low or critical
- **`chain_health`** — test RPC connectivity without requiring a wallet key; reports chain name, chain ID, latest block number, and response time
- Both tools are conditionally registered — only appear when `chain_enabled=true` and blockchain dependencies are installed
- `_format_funding_guidance()` helper is reusable by future write tools (#49, #55, #56) for insufficient-funds errors

## Test plan

- [x] 27 new tests covering handlers, helpers, edge cases, and tool registration
- [x] All 89 tool tests pass (`test_tool_execution.py` + `test_tool_definitions.py`)
- [x] Full suite: 262 passed, 7 skipped, 1 pre-existing flaky e2e (unrelated)
- [x] Chain tools don't appear in `list_tools` when chain is disabled (default)
- [x] RPC URLs are masked to hostname only in output
- [x] Docs updated: README, CLAUDE.md, MCP_usage_ecosystem.md