### PR TITLE
Add provenance skills guide for agents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,7 +174,8 @@ The `config.py` module uses Pydantic Settings for type-safe configuration with a
 - **Response hints**: All success responses append `_next: <tool>` and `_related: <tools>` guiding agents to the logical next step
 - **Structured errors**: All error responses include `retryable: true|false` and `_next` recovery hint
 - **Typo correction**: Unknown tool names get Levenshtein-based "Did you mean?" suggestions
-- **MCP Prompts**: 3 workflow prompts (`provenance-upload`, `provenance-verify`, `stamp-management`) registered via `@server.list_prompts()` / `@server.get_prompt()`
+- **MCP Prompts**: 4 workflow prompts (`provenance-upload`, `provenance-verify`, `stamp-management`, `provenance-chain-workflow`) registered via `@server.list_prompts()` / `@server.get_prompt()`
+- **MCP Resources**: `provenance://skills` resource (SKILLS.md content) via `@server.list_resources()` / `@server.read_resource()`
 - **Cross-server coordination**: health_check reports companion servers (swarm_connect gateway status, fds-id MCP availability)
 - **Insufficient funds**: `_is_insufficient_funds_error()` and `_format_insufficient_funds_error()` provide faucet/bridge URLs
 - **Event-based lineage**: `get_provenance_chain` uses `DataTransformed` contract events (not just record fields) for accurate transformation traversal

--- a/README.md
+++ b/README.md
@@ -484,6 +484,15 @@ The server provides workflow prompts that agents can invoke via `prompts/list` a
 | `provenance-upload` | Upload data to Swarm: health check, stamp selection, upload, verify | `data` (required), `content_type` (optional) |
 | `provenance-verify` | Download and verify existing data by reference | `reference` (required) |
 | `stamp-management` | Review stamp inventory, diagnose issues, recommend actions | none |
+| `provenance-chain-workflow` | End-to-end on-chain provenance: store, anchor, and optionally record a transformation | `data` (required), `transform_description` (optional) |
+
+### MCP Resources
+
+The server exposes on-demand knowledge resources that agents can load via `resources/list` and `resources/read`:
+
+| Resource URI | MIME Type | Description |
+|-------------|-----------|-------------|
+| `provenance://skills` | `text/markdown` | Provenance skills guide — concepts, critical rules, workflows, diagrams, and error recovery |
 
 ## Docker
 

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -1,0 +1,212 @@
+# Provenance Skills Guide
+
+A practical guide for AI agents and developers working with the Swarm Provenance MCP server. Covers concepts, workflows, critical rules, and error recovery for decentralized data provenance.
+
+---
+
+## What is Data Provenance?
+
+Data provenance tracks the **origin, ownership, and transformation history** of data. This system implements provenance across three layers:
+
+| Layer | What it does | Where |
+|-------|-------------|-------|
+| **Swarm Storage** | Content-addressed decentralized storage | Swarm network |
+| **On-Chain Anchoring** | Immutable ownership + timestamp record | Base Sepolia (DataProvenance contract) |
+| **Transformation Lineage** | Links between original and derived data | On-chain event logs |
+
+**Why it matters:** Anyone can verify who stored data, when, and how it was transformed — without trusting a central authority.
+
+---
+
+## Capability Modes
+
+Not every setup has all features. What you can do depends on your configuration:
+
+| Mode | Requirements | Available Tools |
+|------|-------------|-----------------|
+| **Storage Only** | Gateway URL | `purchase_stamp`, `upload_data`, `download_data`, `check_stamp_health`, `get_stamp_status`, `list_stamps`, `extend_stamp`, `health_check`, `get_wallet_info`, `get_notary_info` |
+| **Read-Only Chain** | + `CHAIN_ENABLED=true` | All storage tools + `chain_health`, `verify_hash`, `get_provenance`, `get_provenance_chain` |
+| **Full Provenance** | + `PROVENANCE_WALLET_KEY` (funded) | All tools including `anchor_hash`, `record_transform`, `chain_balance` |
+
+Check your mode: run `health_check` — it reports both gateway and chain status.
+
+---
+
+## Critical Rules
+
+These rules prevent broken on-chain records. Violating them creates data that cannot be corrected (blockchain is immutable).
+
+### 1. `record_transform` auto-registers the new hash
+
+`record_transform` registers `new_hash` on-chain automatically as part of the transformation. **Never call `anchor_hash` on a hash that will be used as `new_hash` in `record_transform`** — doing so creates a standalone record instead of a proper transformation link.
+
+### 2. The original must be anchored first
+
+`record_transform` requires `original_hash` to already be registered on-chain. Always `anchor_hash` the original data before recording any transformations from it.
+
+### 3. Only the owner can record transformations
+
+The wallet that anchored the original hash (or an authorized delegate) is the only one that can call `record_transform` on it. Other wallets will get a revert.
+
+### 4. Stamps and gas are separate payment systems
+
+- **Stamps** (BZZ tokens) pay for Swarm storage — purchased via `purchase_stamp`
+- **Gas** (ETH) pays for blockchain transactions — needed for `anchor_hash` and `record_transform`
+
+These are independent. Having stamps does not help with gas, and vice versa. Check both: `check_stamp_health` for stamps, `chain_balance` for ETH.
+
+### 5. Lineage is a DAG, not a chain
+
+One original hash can have **multiple transformations** (branching). Each transformation creates a new leaf. The structure is a directed acyclic graph (DAG), not a linear chain. Use `get_provenance_chain` to traverse the full tree.
+
+### 6. Status changes are one-way
+
+When `restrict_original=true` is passed to `record_transform`, the original data status changes to RESTRICTED. This **cannot be undone**. Only restrict when you are certain the original should no longer be directly accessed.
+
+---
+
+## Workflows
+
+### A: Store and Anchor (Basic Provenance)
+
+Register data on Swarm with an immutable on-chain ownership record.
+
+```
+1. health_check              → verify gateway + chain connectivity
+2. chain_balance              → confirm wallet has ETH for gas
+3. purchase_stamp             → get a stamp for Swarm storage
+4. check_stamp_health         → poll until can_upload: true
+5. upload_data                → store data, receive reference hash
+6. anchor_hash(swarm_hash)    → register hash on-chain
+7. verify_hash(swarm_hash)    → confirm registration succeeded
+```
+
+### B: Record a Transformation
+
+Link transformed data to its original, creating verifiable lineage.
+
+**Prerequisite:** The original hash must already be anchored (Workflow A).
+
+```
+1. upload_data                → upload the transformed data, get new_hash
+2. record_transform           → link original_hash → new_hash with description
+   (original_hash, new_hash, description)
+3. get_provenance_chain       → verify the lineage is recorded correctly
+```
+
+**Remember:** Do NOT call `anchor_hash` on `new_hash` — `record_transform` handles registration.
+
+### C: Multi-Step Pipeline
+
+Chain multiple transformations (e.g., raw → cleaned → anonymized → aggregated).
+
+```
+1. Anchor the root data       → Workflow A for the original dataset
+2. Transform step 1           → upload cleaned data, record_transform(original, cleaned, "Cleaned")
+3. Transform step 2           → upload anonymized data, record_transform(cleaned, anonymized, "Anonymized PII")
+4. Transform step 3           → upload aggregated data, record_transform(anonymized, aggregated, "Aggregated by region")
+5. get_provenance_chain       → verify the full lineage tree
+```
+
+Each step's `new_hash` becomes the next step's `original_hash`. The auto-registration in `record_transform` ensures each intermediate hash is properly linked.
+
+### D: Verify Existing Provenance (Read-Only)
+
+Inspect provenance records without a wallet.
+
+```
+1. verify_hash(swarm_hash)        → check if hash is registered, get basic info
+2. get_provenance(swarm_hash)     → full record: owner, timestamp, status, transformations
+3. get_provenance_chain(hash)     → follow transformation lineage tree
+4. download_data(reference)       → retrieve the actual data from Swarm
+```
+
+---
+
+## Data Flow
+
+```
+                    ┌─────────────────────────────────────────────┐
+                    │              AI Agent / User                │
+                    └──────────────────┬──────────────────────────┘
+                                       │
+                                  MCP Protocol
+                                       │
+                    ┌──────────────────▼──────────────────────────┐
+                    │         Swarm Provenance MCP Server         │
+                    │                                             │
+                    │  ┌─────────────┐    ┌───────────────────┐   │
+                    │  │   Gateway    │    │   Chain Client     │   │
+                    │  │   Client     │    │   (optional)       │   │
+                    │  └──────┬──────┘    └────────┬──────────┘   │
+                    └─────────┼────────────────────┼──────────────┘
+                              │                    │
+                   ┌──────────▼─────────┐ ┌───────▼──────────────┐
+                   │  swarm_connect     │ │  Base Sepolia RPC    │
+                   │  FastAPI Gateway   │ │                      │
+                   └──────────┬─────────┘ │  DataProvenance      │
+                              │           │  Smart Contract      │
+                   ┌──────────▼─────────┐ └──────────────────────┘
+                   │   Swarm Network    │
+                   │   (Bee nodes)      │
+                   └────────────────────┘
+```
+
+## Transformation Chain
+
+```
+  ┌───────────────────┐     record_transform      ┌───────────────────┐
+  │  hash_0 (original)│ ──────────────────────────▶│  hash_1 (cleaned) │
+  │                   │   "Removed duplicates"     │                   │
+  │  owner: 0xABC...  │                            │  owner: 0xABC...  │
+  │  status: ACTIVE   │                            │  status: ACTIVE   │
+  │  anchored: block N│                            │  anchored: block M│
+  └───────────────────┘                            └─────────┬─────────┘
+                                                             │
+                                                   record_transform
+                                                   "Anonymized PII"
+                                                             │
+                                                   ┌─────────▼─────────┐
+                                                   │  hash_2 (anon)    │
+                                                   │                   │
+                                                   │  owner: 0xABC...  │
+                                                   │  status: ACTIVE   │
+                                                   │  anchored: block P│
+                                                   └───────────────────┘
+
+  get_provenance_chain(hash_0) returns: hash_0 → hash_1 → hash_2
+  get_provenance_chain(hash_1) returns: hash_1 → hash_2
+```
+
+---
+
+## Error Recovery
+
+| Error | Cause | Recovery |
+|-------|-------|----------|
+| "Not usable" / "NOT_FOUND" | Stamp not yet propagated | Poll `check_stamp_health` every 15s (up to 2 min) |
+| "insufficient funds" | Wallet ETH too low for gas | Run `chain_balance` for funding guidance (faucet/bridge URLs) |
+| "already registered" revert | Hash was already anchored | Not an error — `anchor_hash` returns the existing record |
+| "data not registered" | `original_hash` not anchored | Call `anchor_hash` on the original first, then retry `record_transform` |
+| "not owner" / "unauthorized" | Wrong wallet for this data | Only the anchoring wallet (or delegate) can transform |
+| Size exceeded (4KB) | Upload payload too large | Split or compress data before upload |
+| Gateway unreachable | Network or gateway issue | Run `health_check`, check `SWARM_GATEWAY_URL` config |
+| RPC timeout | Blockchain node unresponsive | Run `chain_health`, try again or check `CHAIN_RPC_URL` |
+
+---
+
+## Glossary
+
+| Term | Definition |
+|------|-----------|
+| **Swarm hash** | 64-character hex content address returned by `upload_data` |
+| **Stamp** | Prepaid storage ticket (BZZ) — controls capacity (depth) and duration (TTL) |
+| **Anchor** | Registering a Swarm hash on the blockchain via `anchor_hash` |
+| **Transformation** | On-chain link between an original hash and a derived hash, recorded via `record_transform` |
+| **Lineage / Provenance chain** | The full tree of transformations from a root hash, retrieved via `get_provenance_chain` |
+| **DAG** | Directed Acyclic Graph — the structure of transformation lineage (branching, no cycles) |
+| **Gas** | ETH spent to execute blockchain transactions (`anchor_hash`, `record_transform`) |
+| **Base Sepolia** | Testnet for the Base L2 chain — where the DataProvenance contract is deployed |
+| **DataProvenance contract** | Smart contract that stores provenance records and emits `DataTransformed` events |
+| **Owner** | The wallet address that anchored a hash — has exclusive rights to record transformations |
+| **RESTRICTED status** | Irreversible status set via `restrict_original=true` — signals data should not be accessed directly |

--- a/swarm_provenance_mcp/server.py
+++ b/swarm_provenance_mcp/server.py
@@ -5,17 +5,20 @@ import json
 import logging
 import re
 import time
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence
 from urllib.parse import urlparse
 
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
+from mcp.server.lowlevel.helper_types import ReadResourceContents
 from mcp.types import (
     Tool,
     TextContent,
     CallToolRequest,
     CallToolResult,
     ListToolsRequest,
+    Resource,
     Prompt,
     PromptArgument,
     PromptMessage,
@@ -74,6 +77,17 @@ if settings.chain_enabled:
         else:
             logger.warning("Chain client init failed: %s", e)
 
+def _load_skills_content() -> str:
+    """Load SKILLS.md from repository root for the provenance://skills resource."""
+    skills_path = Path(__file__).parent.parent / "SKILLS.md"
+    try:
+        return skills_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return "Provenance skills guide not found. See MCP_INSTRUCTIONS for basic guidance."
+
+
+_SKILLS_CONTENT = _load_skills_content()
+
 # Agent-facing instructions sent during MCP initialization handshake
 MCP_INSTRUCTIONS = """
 Swarm Provenance MCP — decentralized storage with cryptographic provenance on the Swarm network.
@@ -122,6 +136,22 @@ These register Swarm hashes in the DataProvenance smart contract on Base Sepolia
 - record_transform — record data transformation linking original to new hash, creating lineage (costs gas; optionally restricts original)
 - get_provenance_chain — follow transformation lineage for a hash, building a tree of how data evolved (read-only)
 The health_check tool reports chain status alongside gateway status.
+
+PROVENANCE RULES (critical):
+1. record_transform REGISTERS the new_hash on-chain automatically. NEVER call anchor_hash
+   on a hash that will be the new_hash in record_transform — this creates a duplicate
+   instead of a proper transformation link.
+2. The original_hash MUST be anchored before calling record_transform.
+3. Only the data owner (or authorized delegate) can record transformations.
+4. Stamps (BZZ) pay for Swarm storage; chain anchoring costs ETH gas — separate systems.
+5. Lineage is a DAG: one original can have multiple transformations.
+6. For the full provenance guide with examples and diagrams, read the provenance://skills resource.
+
+CHAIN WORKFLOW — store with on-chain provenance:
+health_check → purchase_stamp → check_stamp_health → upload_data → anchor_hash → verify_hash
+
+CHAIN WORKFLOW — record a transformation:
+upload_data (transformed data) → record_transform (original, new, description) → get_provenance_chain
 
 COMPANION SERVERS:
 - swarm_connect gateway (required) — the FastAPI gateway this server talks to, handles Bee node communication
@@ -795,6 +825,22 @@ def create_server() -> Server:
                 description="Review and manage stamp inventory — list stamps, check health, extend or purchase as needed.",
                 arguments=[],
             ),
+            Prompt(
+                name="provenance-chain-workflow",
+                description="End-to-end on-chain provenance: store data on Swarm, anchor on-chain, and optionally record a transformation.",
+                arguments=[
+                    PromptArgument(
+                        name="data",
+                        description="The data content to store and anchor",
+                        required=True,
+                    ),
+                    PromptArgument(
+                        name="transform_description",
+                        description="If provided, continues the workflow to record a transformation with this description",
+                        required=False,
+                    ),
+                ],
+            ),
         ]
 
     @server.get_prompt()
@@ -882,8 +928,68 @@ def create_server() -> Server:
                 ],
             )
 
+        elif name == "provenance-chain-workflow":
+            data_desc = args.get("data", "<your data here>")
+            transform_desc = args.get("transform_description")
+
+            steps = (
+                f"Store data on Swarm with on-chain provenance:\n\n"
+                f"Data: {data_desc}\n\n"
+                f"Steps:\n"
+                f"1. Call health_check — verify gateway and chain connectivity\n"
+                f"2. Call chain_balance — confirm wallet has ETH for gas\n"
+                f"3. Call purchase_stamp (depth 17 for small data) to get a stamp. "
+                f"Do not pick stamps from list_stamps — they may belong to other users.\n"
+                f"4. Poll check_stamp_health every 15 seconds until can_upload is true (up to 2 minutes)\n"
+                f"5. Call upload_data with the data and your stamp_id — save the reference hash\n"
+                f"6. Call anchor_hash with the reference hash to register it on-chain\n"
+                f"7. Call verify_hash to confirm the on-chain registration succeeded"
+            )
+
+            if transform_desc:
+                steps += (
+                    f"\n\nNow record a transformation ({transform_desc}):\n"
+                    f"8. Call upload_data with the transformed data — save the new reference hash\n"
+                    f"9. CRITICAL: Do NOT call anchor_hash on the new hash. "
+                    f"record_transform registers it automatically.\n"
+                    f"10. Call record_transform with original_hash (from step 5), "
+                    f"new_hash (from step 8), and description: \"{transform_desc}\"\n"
+                    f"11. Call get_provenance_chain on the original hash to verify the lineage"
+                )
+
+            return GetPromptResult(
+                description="End-to-end on-chain provenance workflow",
+                messages=[
+                    PromptMessage(
+                        role="user",
+                        content=TextContent(type="text", text=steps),
+                    )
+                ],
+            )
+
         else:
             raise ValueError(f"Unknown prompt: {name}")
+
+    # --- MCP Resources (on-demand knowledge for agents) ---
+
+    @server.list_resources()
+    async def list_resources() -> list[Resource]:
+        """List available resources."""
+        return [
+            Resource(
+                uri="provenance://skills",
+                name="Provenance Skills Guide",
+                description="Concepts, workflows, critical rules, and diagrams for Swarm data provenance",
+                mimeType="text/markdown",
+            ),
+        ]
+
+    @server.read_resource()
+    async def read_resource(uri) -> list[ReadResourceContents]:
+        """Return resource content by URI."""
+        if str(uri) == "provenance://skills":
+            return [ReadResourceContents(content=_SKILLS_CONTENT, mime_type="text/markdown")]
+        raise ValueError(f"Unknown resource: {uri}")
 
     return server
 

--- a/tests/test_tool_execution.py
+++ b/tests/test_tool_execution.py
@@ -744,7 +744,7 @@ class TestMCPPrompts:
         return create_server()
 
     async def test_list_prompts_returns_all(self, server):
-        """list_prompts should return all 3 workflow prompts."""
+        """list_prompts should return all 4 workflow prompts."""
         handler = None
         for h in server.request_handlers.values():
             if hasattr(h, '__name__') and 'list_prompts' in str(h):
@@ -758,7 +758,10 @@ class TestMCPPrompts:
         prompts = inner.prompts if hasattr(inner, 'prompts') else inner
 
         prompt_names = {p.name for p in prompts}
-        assert prompt_names == {"provenance-upload", "provenance-verify", "stamp-management"}
+        assert prompt_names == {
+            "provenance-upload", "provenance-verify",
+            "stamp-management", "provenance-chain-workflow",
+        }
 
     async def test_provenance_upload_prompt_has_arguments(self, server):
         """provenance-upload prompt should require data argument."""
@@ -3357,3 +3360,153 @@ class TestProvenanceChainEventTraversal:
         # Should still include the first record (bb*32 not found but attempted)
         assert len(chain) == 1
         assert chain[0].data_hash == "aa" * 32
+
+
+class TestProvenanceChainWorkflowPrompt:
+    """Test the provenance-chain-workflow prompt."""
+
+    @pytest.fixture
+    def server(self):
+        return create_server()
+
+    async def test_chain_workflow_prompt_basic(self, server):
+        """provenance-chain-workflow prompt should return anchoring steps."""
+        handler = None
+        for h in server.request_handlers.values():
+            if hasattr(h, '__name__') and 'get_prompt' in str(h):
+                handler = h
+                break
+
+        assert handler is not None, "get_prompt handler not registered"
+        from mcp.types import GetPromptRequest
+        result = await handler(GetPromptRequest(
+            method="prompts/get",
+            params={"name": "provenance-chain-workflow", "arguments": {"data": "test data"}}
+        ))
+        inner = result.root if hasattr(result, 'root') else result
+        text = inner.messages[0].content.text
+
+        assert "health_check" in text
+        assert "chain_balance" in text
+        assert "anchor_hash" in text
+        assert "verify_hash" in text
+        # Should NOT include transform steps without transform_description
+        assert "record_transform" not in text
+
+    async def test_chain_workflow_prompt_with_transform(self, server):
+        """provenance-chain-workflow with transform_description should include transform steps."""
+        handler = None
+        for h in server.request_handlers.values():
+            if hasattr(h, '__name__') and 'get_prompt' in str(h):
+                handler = h
+                break
+
+        from mcp.types import GetPromptRequest
+        result = await handler(GetPromptRequest(
+            method="prompts/get",
+            params={
+                "name": "provenance-chain-workflow",
+                "arguments": {
+                    "data": "original data",
+                    "transform_description": "Anonymized PII",
+                },
+            }
+        ))
+        inner = result.root if hasattr(result, 'root') else result
+        text = inner.messages[0].content.text
+
+        assert "record_transform" in text
+        assert "Anonymized PII" in text
+        assert "Do NOT call anchor_hash on the new hash" in text
+        assert "get_provenance_chain" in text
+
+    async def test_chain_workflow_prompt_has_arguments(self, server):
+        """provenance-chain-workflow should have data (required) and transform_description (optional)."""
+        handler = None
+        for h in server.request_handlers.values():
+            if hasattr(h, '__name__') and 'list_prompts' in str(h):
+                handler = h
+                break
+
+        from mcp.types import ListPromptsRequest
+        result = await handler(ListPromptsRequest(method="prompts/list"))
+        inner = result.root if hasattr(result, 'root') else result
+        prompts = inner.prompts if hasattr(inner, 'prompts') else inner
+
+        chain_prompt = next(p for p in prompts if p.name == "provenance-chain-workflow")
+        arg_names = {a.name for a in chain_prompt.arguments}
+        assert arg_names == {"data", "transform_description"}
+        data_arg = next(a for a in chain_prompt.arguments if a.name == "data")
+        assert data_arg.required is True
+        transform_arg = next(a for a in chain_prompt.arguments if a.name == "transform_description")
+        assert transform_arg.required is False
+
+
+class TestMCPResources:
+    """Test MCP resource handlers."""
+
+    @pytest.fixture
+    def server(self):
+        return create_server()
+
+    async def test_list_resources_includes_skills(self, server):
+        """list_resources should include the provenance://skills resource."""
+        handler = None
+        for h in server.request_handlers.values():
+            if hasattr(h, '__name__') and 'list_resources' in str(h):
+                handler = h
+                break
+
+        assert handler is not None, "list_resources handler not registered"
+        from mcp.types import ListResourcesRequest
+        result = await handler(ListResourcesRequest(method="resources/list"))
+        inner = result.root if hasattr(result, 'root') else result
+        resources = inner.resources if hasattr(inner, 'resources') else inner
+
+        uris = [str(r.uri) for r in resources]
+        assert "provenance://skills" in uris
+
+        skills_resource = next(r for r in resources if str(r.uri) == "provenance://skills")
+        assert skills_resource.mimeType == "text/markdown"
+        assert "provenance" in skills_resource.description.lower()
+
+    async def test_read_skills_resource_returns_content(self, server):
+        """read_resource for provenance://skills should return SKILLS.md content."""
+        handler = None
+        for h in server.request_handlers.values():
+            if hasattr(h, '__name__') and 'read_resource' in str(h):
+                handler = h
+                break
+
+        assert handler is not None, "read_resource handler not registered"
+        from pydantic import AnyUrl
+        from mcp.types import ReadResourceRequest
+        result = await handler(ReadResourceRequest(
+            method="resources/read",
+            params={"uri": "provenance://skills"},
+        ))
+        inner = result.root if hasattr(result, 'root') else result
+        contents = inner if isinstance(inner, list) else inner.contents if hasattr(inner, 'contents') else [inner]
+
+        assert len(contents) >= 1
+        text = contents[0].content if hasattr(contents[0], 'content') else str(contents[0])
+        assert len(text) > 100
+        # Check for key sections from SKILLS.md
+        assert "Critical Rules" in text or "critical" in text.lower()
+        assert "Workflow" in text or "workflow" in text.lower()
+
+    async def test_read_unknown_resource_raises(self, server):
+        """read_resource for unknown URI should raise ValueError."""
+        handler = None
+        for h in server.request_handlers.values():
+            if hasattr(h, '__name__') and 'read_resource' in str(h):
+                handler = h
+                break
+
+        assert handler is not None
+        from mcp.types import ReadResourceRequest
+        with pytest.raises((ValueError, Exception)):
+            await handler(ReadResourceRequest(
+                method="resources/read",
+                params={"uri": "provenance://unknown"},
+            ))

--- a/tests/test_tool_sync_validation.py
+++ b/tests/test_tool_sync_validation.py
@@ -183,7 +183,7 @@ class TestToolSynchronization:
         prompts = inner.prompts if hasattr(inner, 'prompts') else inner
         prompt_names = {p.name for p in prompts}
 
-        expected_prompts = {'provenance-upload', 'provenance-verify', 'stamp-management'}
+        expected_prompts = {'provenance-upload', 'provenance-verify', 'stamp-management', 'provenance-chain-workflow'}
         missing = expected_prompts - prompt_names
         assert not missing, f"Prompts not registered at runtime: {missing}"
 


### PR DESCRIPTION
## Summary

- Created `SKILLS.md` — provenance skills guide with concepts, critical rules, 4 workflows, ASCII diagrams, error recovery, and glossary
- Added `provenance://skills` MCP resource (serves SKILLS.md on demand)
- Added `provenance-chain-workflow` MCP prompt for step-by-step chain anchoring + transformation
- Updated `MCP_INSTRUCTIONS` with 6 critical provenance rules and workflow summaries
- Updated README and CLAUDE.md to document the new prompt and resource

## Test plan

- [x] 7 new tests (3 prompt, 3 resource, 1 prompt count update)
- [x] Updated `test_tool_sync_validation.py` prompt assertion
- [x] Full suite: 387 passed, 0 failures

Closes #93