### PR TITLE
Stamp ownership model, provenance chain fixes, docs updates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,13 +100,14 @@ On-chain provenance module. Dependencies (web3, eth-account) included in default
 ### Available MCP Tools
 
 #### Swarm Gateway Tools
-- `purchase_stamp` - Create new postage stamps
-- `get_stamp_status` - Retrieve detailed stamp information (includes utilization data)
-- `list_stamps` - List all available stamps
+- `purchase_stamp` - Create new postage stamps (response includes propagation timing)
+- `get_stamp_status` - Retrieve detailed stamp information (includes utilization + propagation data)
+- `list_stamps` - List local stamps with access mode (owned/shared) and propagation status
+  Stamps have `accessMode`: `"owned"` (dedicated, yours) or `"shared"` (public, any gateway user). Use owned stamps for production.
 - `extend_stamp` - Add funds to existing stamps
 - `upload_data` - Upload data to Swarm (max 4KB)
 - `download_data` - Download data from Swarm by reference hash
-- `check_stamp_health` - Diagnose stamp upload readiness with errors/warnings
+- `check_stamp_health` - Diagnose stamp upload readiness with errors/warnings and propagation timing
 - `get_wallet_info` - Node wallet address and BZZ balance (debug, may be removed)
 - `get_notary_info` - Check notary signing service availability
 - `health_check` - Gateway connectivity status
@@ -119,7 +120,7 @@ On-chain provenance module. Dependencies (web3, eth-account) included in default
 | `chain_balance` | **required** | no | Check wallet ETH balance with funding guidance |
 | `verify_hash` | not needed | no | Check if hash is registered on-chain |
 | `get_provenance` | not needed | no | Retrieve full on-chain provenance record |
-| `get_provenance_chain` | not needed | no | Follow transformation lineage tree via event logs |
+| `get_provenance_chain` | not needed | no | Follow transformation lineage tree bidirectionally via event logs |
 | `anchor_hash` | **required** | **yes** | Register Swarm hash on-chain |
 | `record_transform` | **required** | **yes** | Record data transformation, link original → new hash |
 
@@ -178,7 +179,7 @@ The `config.py` module uses Pydantic Settings for type-safe configuration with a
 - **MCP Resources**: `provenance://skills` resource (SKILLS.md content) via `@server.list_resources()` / `@server.read_resource()`
 - **Cross-server coordination**: health_check reports companion servers (swarm_connect gateway status, fds-id MCP availability)
 - **Insufficient funds**: `_is_insufficient_funds_error()` and `_format_insufficient_funds_error()` provide faucet/bridge URLs
-- **Event-based lineage**: `get_provenance_chain` uses `DataTransformed` contract events (not just record fields) for accurate transformation traversal
+- **Event-based lineage**: `get_provenance_chain` uses `DataTransformed` contract events bidirectionally (forward via `originalDataHash`, reverse via `newDataHash`) for accurate transformation traversal from any node
 - Helper functions: `_format_hints()`, `_format_error()`, `_is_retryable_error()`, `_suggest_tool_name()`
 
 ### Code Quality
@@ -206,8 +207,8 @@ Before submitting changes:
 This MCP server requires a running `swarm_connect` FastAPI gateway service. The gateway must be accessible at the configured `SWARM_GATEWAY_URL` and provide the following endpoints:
 - `POST /api/v1/stamps/` - Purchase stamps
 - `GET /api/v1/stamps/` - List stamps
-- `GET /api/v1/stamps/{id}` - Get stamp details
-- `GET /api/v1/stamps/{id}/check` - Stamp health check
+- `GET /api/v1/stamps/{id}` - Get stamp details (includes `propagationStatus`, `secondsSincePurchase`, `estimatedReadyAt`)
+- `GET /api/v1/stamps/{id}/check` - Stamp health check (includes propagation timing fields)
 - `PATCH /api/v1/stamps/{id}/extend` - Extend stamps
 - `POST /api/v1/data/` - Upload data
 - `GET /api/v1/data/{reference}` - Download data

--- a/MCP_usage_ecosystem.md
+++ b/MCP_usage_ecosystem.md
@@ -111,7 +111,7 @@ Our Swarm Provenance MCP server currently provides these tools:
 
 - `purchase_stamp` - Create new postage stamps for data uploads
 - `get_stamp_status` - Check stamp details and utilization
-- `list_stamps` - View all available stamps
+- `list_stamps` - List local stamps with access mode (owned/shared)
 - `extend_stamp` - Add funds to existing stamps
 - `upload_data` - Store data on Swarm network (4KB limit)
 - `download_data` - Retrieve data from Swarm by reference

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -74,8 +74,8 @@ Register data on Swarm with an immutable on-chain ownership record.
 ```
 1. health_check              → verify gateway + chain connectivity
 2. chain_balance              → confirm wallet has ETH for gas
-3. purchase_stamp             → get a stamp for Swarm storage
-4. check_stamp_health         → poll until can_upload: true
+3. purchase_stamp             → get a stamp for Swarm storage (check propagationStatus in response)
+4. check_stamp_health         → poll until can_upload: true (uses propagationStatus + estimatedReadyAt)
 5. upload_data                → store data, receive reference hash
 6. anchor_hash(swarm_hash)    → register hash on-chain
 7. verify_hash(swarm_hash)    → confirm registration succeeded
@@ -175,7 +175,8 @@ Inspect provenance records without a wallet.
                                                    └───────────────────┘
 
   get_provenance_chain(hash_0) returns: hash_0 → hash_1 → hash_2
-  get_provenance_chain(hash_1) returns: hash_1 → hash_2
+  get_provenance_chain(hash_2) returns: hash_0 → hash_1 → hash_2  (walks backward to root)
+  get_provenance_chain(hash_1) returns: hash_0 → hash_1 → hash_2  (walks both directions)
 ```
 
 ---
@@ -184,9 +185,10 @@ Inspect provenance records without a wallet.
 
 | Error | Cause | Recovery |
 |-------|-------|----------|
-| "Not usable" / "NOT_FOUND" | Stamp not yet propagated | Poll `check_stamp_health` every 15s (up to 2 min) |
+| "Not usable" / "NOT_FOUND" | Stamp not yet propagated | Check `propagationStatus` and `estimatedReadyAt` in the response. Poll `check_stamp_health` every 15s until `propagationStatus: "ready"` |
 | "insufficient funds" | Wallet ETH too low for gas | Run `chain_balance` for funding guidance (faucet/bridge URLs) |
 | "already registered" revert | Hash was already anchored | Not an error — `anchor_hash` returns the existing record |
+| "already exists" / "already registered" revert on `record_transform` | `new_hash` was pre-anchored via `anchor_hash` | Do NOT anchor `new_hash` before `record_transform` — it auto-registers. Re-upload the data to get a fresh hash. |
 | "data not registered" | `original_hash` not anchored | Call `anchor_hash` on the original first, then retry `record_transform` |
 | "not owner" / "unauthorized" | Wrong wallet for this data | Only the anchoring wallet (or delegate) can transform |
 | Size exceeded (4KB) | Upload payload too large | Split or compress data before upload |
@@ -203,10 +205,12 @@ Inspect provenance records without a wallet.
 | **Stamp** | Prepaid storage ticket (BZZ) — controls capacity (depth) and duration (TTL) |
 | **Anchor** | Registering a Swarm hash on the blockchain via `anchor_hash` |
 | **Transformation** | On-chain link between an original hash and a derived hash, recorded via `record_transform` |
-| **Lineage / Provenance chain** | The full tree of transformations from a root hash, retrieved via `get_provenance_chain` |
+| **Lineage / Provenance chain** | The full tree of transformations reachable from any hash (walks both directions), retrieved via `get_provenance_chain` |
 | **DAG** | Directed Acyclic Graph — the structure of transformation lineage (branching, no cycles) |
 | **Gas** | ETH spent to execute blockchain transactions (`anchor_hash`, `record_transform`) |
 | **Base Sepolia** | Testnet for the Base L2 chain — where the DataProvenance contract is deployed |
 | **DataProvenance contract** | Smart contract that stores provenance records and emits `DataTransformed` events |
 | **Owner** | The wallet address that anchored a hash — has exclusive rights to record transformations |
 | **RESTRICTED status** | Irreversible status set via `restrict_original=true` — signals data should not be accessed directly |
+| **Owned stamp** | A stamp purchased by your wallet — exclusive access, predictable utilization, production-ready |
+| **Public stamp** | A stamp available to all gateway users (accessMode: "shared" in API) — utilization is unpredictable, suitable for testing |

--- a/swarm_provenance_mcp/chain/client.py
+++ b/swarm_provenance_mcp/chain/client.py
@@ -777,6 +777,22 @@ class ChainClient:
                     if t.new_data_hash and t.new_data_hash not in visited:
                         to_visit.append((t.new_data_hash, current_depth + 1))
 
+            # Reverse: transformations TO this hash (find parents)
+            try:
+                reverse_events = self._contract.get_transformations_to(current_hash)
+                for orig_bytes, new_bytes, desc in reverse_events:
+                    orig_hash = (
+                        orig_bytes.hex()
+                        if isinstance(orig_bytes, bytes)
+                        else str(orig_bytes)
+                    )
+                    if orig_hash not in visited:
+                        to_visit.append((orig_hash, current_depth + 1))
+            except Exception:
+                logger.debug(
+                    "Could not query reverse events for %s", current_hash
+                )
+
             chain.append(record)
 
         logger.debug("Chain length: %d", len(chain))

--- a/swarm_provenance_mcp/chain/contract.py
+++ b/swarm_provenance_mcp/chain/contract.py
@@ -611,6 +611,38 @@ class DataProvenanceContract:
             ))
         return results
 
+    def get_transformations_to(
+        self,
+        data_hash: str,
+        lookback_blocks: int = 5_000,
+    ) -> List[Tuple[bytes, bytes, str]]:
+        """
+        Query DataTransformed events where data_hash is the new (reverse lookup).
+
+        Args:
+            data_hash: 64-char hex hash.
+            lookback_blocks: How many blocks to scan backwards from latest.
+
+        Returns:
+            List of (originalDataHash, newDataHash, description) tuples.
+        """
+        hash_bytes = _normalize_hash(data_hash)
+        latest = self._web3.eth.block_number
+        from_block = max(0, latest - lookback_blocks)
+        events = self._contract.events.DataTransformed.get_logs(
+            argument_filters={"newDataHash": hash_bytes},
+            from_block=from_block,
+            to_block=latest,
+        )
+        results = []
+        for evt in events:
+            results.append((
+                evt.args.originalDataHash,
+                evt.args.newDataHash,
+                evt.args.transformation,
+            ))
+        return results
+
     # --- Gas estimation ---
 
     def estimate_gas(self, tx: dict) -> int:

--- a/swarm_provenance_mcp/gateway_client.py
+++ b/swarm_provenance_mcp/gateway_client.py
@@ -99,7 +99,7 @@ class SwarmGatewayClient:
         return response.json()
 
     def list_stamps(self) -> Dict[str, Any]:
-        """List all available stamps.
+        """List local stamps available on the gateway.
 
         Returns:
             Response containing list of stamps and total count

--- a/swarm_provenance_mcp/server.py
+++ b/swarm_provenance_mcp/server.py
@@ -95,6 +95,11 @@ Swarm Provenance MCP — decentralized storage with cryptographic provenance on 
 PAYMENT MODEL:
 This server uses the free tier by default (rate limit: 3 write requests/minute, reads unlimited). Paid x402 support is not yet integrated.
 
+STAMP OWNERSHIP:
+- Free tier: purchase_stamp provides public stamps (accessMode: "shared"). Any gateway user can upload to them — utilization is unpredictable. Suitable for testing and small workloads.
+- Own wallet: stamps you purchase are exclusively yours (accessMode: "owned"). You control capacity and TTL. Use owned stamps for production workloads.
+- list_stamps shows both. Prefer owned stamps for important data; public stamps may fill up from other users' uploads.
+
 TYPICAL WORKFLOW:
 1. health_check — verify gateway is reachable
 2. purchase_stamp — create your own stamp (or use one you previously purchased)
@@ -106,8 +111,6 @@ TYPICAL WORKFLOW:
 5. download_data — retrieve data using the reference hash
 
 KEY CONSTRAINTS:
-- Always use stamps YOU purchased via purchase_stamp. Do not use arbitrary stamps from list_stamps — they may belong to other users and will fail on upload.
-- list_stamps shows all network-visible stamps, not just yours. Track your stamp IDs from purchase_stamp responses.
 - Max upload size: 4KB (4096 bytes) per request
 - After purchase_stamp, the stamp may be instantly usable (pool) or take up to 2 minutes (fresh mint). Poll with check_stamp_health every 10-15 seconds until can_upload is true.
 - After extend_stamp, wait up to 2 minutes for the extension to propagate.
@@ -489,7 +492,7 @@ def create_server() -> Server:
             ),
             Tool(
                 name="list_stamps",
-                description="List all available postage stamps with their details including batch IDs, amounts, depths, TTL, expiration times, and utilization. Useful for finding a usable stamp for upload_data or identifying stamps that need extending.",
+                description="List postage stamps available on the gateway. Each stamp includes access mode: owned (yours, dedicated) or shared (public, any gateway user). Also shows usability status and expiration.",
                 inputSchema={"type": "object", "properties": {}, "required": []},
             ),
             Tool(
@@ -608,7 +611,7 @@ def create_server() -> Server:
                     ),
                     Tool(
                         name="anchor_hash",
-                        description="Register a Swarm reference hash on the blockchain, creating an immutable provenance record with owner, timestamp, and data type. Costs gas — requires a funded wallet (check with chain_balance). If the hash is already registered, returns the existing record without error.",
+                        description="Register a Swarm reference hash on the blockchain, creating an immutable provenance record with owner, timestamp, and data type. Costs gas — requires a funded wallet (check with chain_balance). If the hash is already registered, returns the existing record without error. Do not use this on hashes that will be the new_hash in record_transform — record_transform auto-registers them.",
                         inputSchema={
                             "type": "object",
                             "properties": {
@@ -664,7 +667,7 @@ def create_server() -> Server:
                     ),
                     Tool(
                         name="record_transform",
-                        description="Record a data transformation on-chain, linking the original data to its transformed version. Creates a verifiable lineage trail. The original hash must already be anchored. Optionally restricts access to the original data after transformation. Costs gas.",
+                        description="Record a data transformation on-chain, linking the original data to its transformed version. Creates a verifiable lineage trail. The original hash must already be anchored. The new_hash must NOT be previously anchored — record_transform registers it automatically. Optionally restricts access to the original data after transformation. Costs gas.",
                         inputSchema={
                             "type": "object",
                             "properties": {
@@ -694,7 +697,7 @@ def create_server() -> Server:
                     ),
                     Tool(
                         name="get_provenance_chain",
-                        description="Follow the transformation lineage for a Swarm hash. Walks through all recorded transformations to show how data evolved — from original to each derived version. Read-only, no gas or wallet key required.",
+                        description="Follow the transformation lineage for a Swarm hash. Walks both directions — from any node it finds parents (originals) and children (derived versions). Can be called on a leaf, middle, or root hash. Read-only, no gas or wallet key required.",
                         inputSchema={
                             "type": "object",
                             "properties": {
@@ -866,8 +869,8 @@ def create_server() -> Server:
                                 f"Content-Type: {content_type}\n\n"
                                 f"Follow these steps:\n"
                                 f"1. Call health_check to verify the gateway is reachable\n"
-                                f"2. Call purchase_stamp (depth 17 for small data) to get your own stamp. "
-                                f"Do not pick stamps from list_stamps — they may belong to other users.\n"
+                                f"2. Call purchase_stamp (depth 17 for small data) to get your own stamp, "
+                                f"or use an owned stamp from list_stamps.\n"
                                 f"3. Poll check_stamp_health every 15 seconds until ready (up to 2 minutes)\n"
                                 f"4. Call upload_data with the data and your stamp_id\n"
                                 f"5. Call download_data with the returned reference to verify the upload\n"
@@ -911,8 +914,7 @@ def create_server() -> Server:
                             type="text",
                             text=(
                                 "Review my Swarm stamp inventory and recommend actions:\n\n"
-                                "Note: list_stamps shows all network-visible stamps, not just yours. "
-                                "Only manage stamps you purchased via purchase_stamp.\n\n"
+                                "list_stamps shows your owned stamps and public stamps. Stamps with accessMode 'owned' are yours; 'shared' are public stamps usable by any gateway user. If you only have public stamps, recommend purchasing dedicated stamps or running your own node for production use.\n\n"
                                 "Steps:\n"
                                 "1. Call list_stamps to see all stamps\n"
                                 "2. For stamps you own, check if usable, utilization, and TTL\n"
@@ -938,8 +940,8 @@ def create_server() -> Server:
                 f"Steps:\n"
                 f"1. Call health_check — verify gateway and chain connectivity\n"
                 f"2. Call chain_balance — confirm wallet has ETH for gas\n"
-                f"3. Call purchase_stamp (depth 17 for small data) to get a stamp. "
-                f"Do not pick stamps from list_stamps — they may belong to other users.\n"
+                f"3. Call purchase_stamp (depth 17 for small data) to get a stamp, "
+                f"or use an owned stamp from list_stamps.\n"
                 f"4. Poll check_stamp_health every 15 seconds until can_upload is true (up to 2 minutes)\n"
                 f"5. Call upload_data with the data and your stamp_id — save the reference hash\n"
                 f"6. Call anchor_hash with the reference hash to register it on-chain\n"
@@ -1047,11 +1049,18 @@ async def handle_purchase_stamp(arguments: Dict[str, Any]) -> CallToolResult:
         if label:
             response_text += f"   Label: {label}\n"
         response_text += f"\n✅ Stamp ID: `{batch_id}`\n"
-        response_text += f"⏱️  Your stamp may be ready immediately (from the gateway pool) or may need\n"
-        response_text += f"   up to 2 minutes to propagate on the blockchain.\n"
-        response_text += (
-            f"   → Use check_stamp_health to confirm it's ready before uploading."
-        )
+
+        propagation_status = result.get("propagationStatus")
+        estimated_ready = result.get("estimatedReadyAt")
+        if propagation_status == "ready":
+            response_text += "⏱️  Stamp is ready immediately (from the gateway pool).\n"
+        elif propagation_status == "propagating" and estimated_ready:
+            response_text += f"⏱️  Stamp is propagating — estimated ready at {estimated_ready}.\n"
+            response_text += "   → Use check_stamp_health to confirm it's ready before uploading."
+        else:
+            response_text += "⏱️  Your stamp may be ready immediately (from the gateway pool) or may need\n"
+            response_text += "   up to 2 minutes to propagate on the blockchain.\n"
+            response_text += "   → Use check_stamp_health to confirm it's ready before uploading."
         response_text += _format_hints(
             "check_stamp_health", ["get_stamp_status", "upload_data", "list_stamps"]
         )
@@ -1142,6 +1151,19 @@ async def handle_get_stamp_status(arguments: Dict[str, Any]) -> CallToolResult:
         if result.get("label"):
             response_text += f"Label: {result['label']}\n"
 
+        # Propagation timing (from gateway, when available)
+        propagation_status = result.get("propagationStatus")
+        seconds_since = result.get("secondsSincePurchase")
+        estimated_ready = result.get("estimatedReadyAt")
+
+        if propagation_status:
+            response_text += f"Propagation: {propagation_status}"
+            if seconds_since is not None:
+                response_text += f" ({seconds_since}s since purchase)"
+            if estimated_ready and propagation_status == "propagating":
+                response_text += f" — ready at {estimated_ready}"
+            response_text += "\n"
+
         # Contextual hints based on usability
         if usable is True:
             response_text += _format_hints(
@@ -1198,7 +1220,6 @@ async def handle_list_stamps(arguments: Dict[str, Any]) -> CallToolResult:
             response_text = "📭 No stamps found.\n\n💡 Use the 'purchase_stamp' tool to create your first stamp!"
         else:
             response_text = f"📋 Found {total_count} stamp(s):\n\n"
-            response_text += "⚠️  Note: This list includes all network-visible stamps. For uploads, use stamps you purchased via purchase_stamp.\n\n"
 
             for stamp in stamps:
                 batch_id = stamp.get("batchID", "N/A")
@@ -1217,7 +1238,23 @@ async def handle_list_stamps(arguments: Dict[str, Any]) -> CallToolResult:
                     status = "❓ Unknown"
 
                 response_text += f"Batch ID: {batch_id}\n"
-                response_text += f"  Expiration: {expiration} | Status: {status}\n\n"
+                detail_line = f"  Expiration: {expiration} | Status: {status}"
+
+                # Surface access mode when provided by gateway
+                access_mode = stamp.get("accessMode")
+                if access_mode:
+                    detail_line += f" | Access: {access_mode}"
+
+                # Surface propagation status when provided
+                propagation_status = stamp.get("propagationStatus")
+                if propagation_status:
+                    detail_line += f" | Propagation: {propagation_status}"
+
+                response_text += detail_line + "\n\n"
+
+        # Public-only hint: all stamps are shared, none owned
+        if stamps and not any(s.get("accessMode") == "owned" for s in stamps):
+            response_text += "\n💡 All stamps are public (shared). For production use with predictable capacity, configure your own wallet for dedicated stamps.\n"
 
         # Contextual hints
         if has_usable:
@@ -1565,7 +1602,7 @@ async def handle_health_check(arguments: Dict[str, Any]) -> CallToolResult:
                 usable_count = sum(1 for s in stamps if s.get("usable") is True)
 
                 stamps_info += (
-                    f"\n📋 Stamps: {usable_count} usable / {total_stamps} total\n"
+                    f"\n📋 Stamps: {usable_count} usable / {total_stamps} local\n"
                 )
 
                 if usable_count > 0:
@@ -1726,23 +1763,44 @@ async def handle_check_stamp_health(arguments: Dict[str, Any]) -> CallToolResult
             if status.get("expectedExpiration"):
                 response_text += f"   Expires: {status['expectedExpiration']}\n"
 
+        # Propagation timing (from gateway, when available)
+        propagation_status = result.get("propagationStatus")
+        seconds_since = result.get("secondsSincePurchase")
+        estimated_ready = result.get("estimatedReadyAt")
+
+        if propagation_status:
+            response_text += f"\nPropagation:\n"
+            response_text += f"   Status: {propagation_status}\n"
+            if seconds_since is not None:
+                response_text += f"   Purchased: {seconds_since}s ago\n"
+            if estimated_ready:
+                response_text += f"   Estimated ready: {estimated_ready}\n"
+
         # Contextual hints based on health
         if can_upload:
             response_text += _format_hints(
                 "upload_data", ["get_stamp_status", "extend_stamp"]
             )
         else:
-            # Detect propagation scenario: NOT_FOUND or NOT_USABLE with 0% utilization
-            error_codes = {e.get("code", "") for e in errors}
-            util_pct = (status.get("utilizationPercent") or 0) if status else 0
-            is_propagating = ("NOT_FOUND" in error_codes) or (
-                "NOT_USABLE" in error_codes and util_pct == 0
-            )
-            if is_propagating:
-                response_text += (
-                    "\n💡 If recently purchased, the stamp is propagating on the blockchain. "
-                    "This typically takes up to 2 minutes. Retry check_stamp_health in 15 seconds."
+            # Detect propagation: prefer gateway field, fall back to heuristic
+            is_propagating = propagation_status == "propagating"
+            if not is_propagating:
+                error_codes = {e.get("code", "") for e in errors}
+                util_pct = (status.get("utilizationPercent") or 0) if status else 0
+                is_propagating = ("NOT_FOUND" in error_codes) or (
+                    "NOT_USABLE" in error_codes and util_pct == 0
                 )
+            if is_propagating:
+                if estimated_ready:
+                    response_text += (
+                        f"\n💡 Stamp is propagating. Estimated ready at {estimated_ready}. "
+                        "Retry check_stamp_health in 15 seconds."
+                    )
+                else:
+                    response_text += (
+                        "\n💡 If recently purchased, the stamp is propagating on the blockchain. "
+                        "This typically takes up to 2 minutes. Retry check_stamp_health in 15 seconds."
+                    )
                 response_text += _format_hints(
                     "check_stamp_health", ["list_stamps", "extend_stamp"]
                 )
@@ -2788,6 +2846,22 @@ async def handle_get_provenance_chain(arguments: Dict[str, Any]) -> CallToolResu
                         for t in record.transformations:
                             if t.new_data_hash and t.new_data_hash not in visited:
                                 to_visit.append((t.new_data_hash, depth + 1))
+
+                    # Reverse: find parents
+                    try:
+                        reverse_events = contract.get_transformations_to(
+                            current_hash
+                        )
+                        for orig_bytes, new_bytes, desc in reverse_events:
+                            orig_hash = (
+                                orig_bytes.hex()
+                                if isinstance(orig_bytes, bytes)
+                                else str(orig_bytes)
+                            )
+                            if orig_hash not in visited:
+                                to_visit.append((orig_hash, depth + 1))
+                    except Exception:
+                        pass
 
                     chain_records.append(record)
                 except Exception:

--- a/tests/test_tool_execution.py
+++ b/tests/test_tool_execution.py
@@ -97,7 +97,9 @@ class TestToolExecution:
                         "batchID": TEST_STAMP_ID,
                         "amount": "2000000000",
                         "depth": 17,
-                        "utilization": 0.1
+                        "utilization": 0.1,
+                        "usable": True,
+                        "accessMode": "owned",
                     }
                 ],
                 "total_count": 1
@@ -198,6 +200,8 @@ class TestToolExecution:
         # Verify response contains stamp information
         content_text = result.content[0].text
         assert "stamp" in content_text.lower()
+        # Outdated network-visible warning must not appear
+        assert "network-visible" not in content_text
 
     async def test_extend_stamp_tool(self, server, mock_gateway_client):
         """Test extend_stamp tool execution."""
@@ -536,6 +540,239 @@ class TestResponseHints:
         )
         text = result.content[0].text
         assert "_next: purchase_stamp" in text
+
+
+class TestPropagationFields:
+    """Test that stamp handlers surface gateway propagation timing fields."""
+
+    @pytest.fixture
+    def server(self):
+        return create_server()
+
+    async def test_health_check_shows_propagation_status(self, server):
+        """check_stamp_health should display propagationStatus and timing."""
+        with patch('swarm_provenance_mcp.server.gateway_client') as mock_client:
+            mock_client.check_stamp_health.return_value = {
+                "stamp_id": TEST_STAMP_ID,
+                "can_upload": False,
+                "errors": [{"code": "NOT_USABLE", "message": "Not usable yet"}],
+                "warnings": [],
+                "status": {"utilizationPercent": 0},
+                "propagationStatus": "propagating",
+                "secondsSincePurchase": 30,
+                "estimatedReadyAt": "2026-03-16T12:30:00Z",
+            }
+            result = await call_tool_directly(
+                server, "check_stamp_health", {"stamp_id": TEST_STAMP_ID}
+            )
+
+        text = result.content[0].text
+        assert "propagating" in text
+        assert "30s ago" in text
+        assert "2026-03-16T12:30:00Z" in text
+
+    async def test_health_check_propagating_uses_estimated_ready(self, server):
+        """Propagating stamp should show estimated ready time in hint."""
+        with patch('swarm_provenance_mcp.server.gateway_client') as mock_client:
+            mock_client.check_stamp_health.return_value = {
+                "stamp_id": TEST_STAMP_ID,
+                "can_upload": False,
+                "errors": [{"code": "NOT_USABLE", "message": "Not usable"}],
+                "warnings": [],
+                "status": {},
+                "propagationStatus": "propagating",
+                "secondsSincePurchase": 15,
+                "estimatedReadyAt": "2026-03-16T12:32:00Z",
+            }
+            result = await call_tool_directly(
+                server, "check_stamp_health", {"stamp_id": TEST_STAMP_ID}
+            )
+
+        text = result.content[0].text
+        assert "Estimated ready at 2026-03-16T12:32:00Z" in text
+        assert "_next: check_stamp_health" in text
+
+    async def test_health_check_no_propagation_fields(self, server):
+        """Older gateway without propagation fields should fall back to heuristic."""
+        with patch('swarm_provenance_mcp.server.gateway_client') as mock_client:
+            mock_client.check_stamp_health.return_value = {
+                "stamp_id": TEST_STAMP_ID,
+                "can_upload": False,
+                "errors": [{"code": "NOT_FOUND", "message": "Not found"}],
+                "warnings": [],
+                "status": {},
+            }
+            result = await call_tool_directly(
+                server, "check_stamp_health", {"stamp_id": TEST_STAMP_ID}
+            )
+
+        text = result.content[0].text
+        assert "propagating on the blockchain" in text
+        assert "_next: check_stamp_health" in text
+
+    async def test_stamp_status_shows_propagation(self, server):
+        """get_stamp_status should display propagation fields when present."""
+        with patch('swarm_provenance_mcp.server.gateway_client') as mock_client:
+            mock_client.get_stamp_details.return_value = {
+                "amount": "2000000000",
+                "depth": 17,
+                "bucketDepth": 16,
+                "blockNumber": 12345,
+                "batchTTL": 86400,
+                "expectedExpiration": "2026-04-15",
+                "usable": False,
+                "utilization": 0,
+                "immutableFlag": False,
+                "local": True,
+                "propagationStatus": "propagating",
+                "secondsSincePurchase": 45,
+                "estimatedReadyAt": "2026-03-16T12:35:00Z",
+            }
+            result = await call_tool_directly(
+                server, "get_stamp_status", {"stamp_id": TEST_STAMP_ID}
+            )
+
+        text = result.content[0].text
+        assert "propagating" in text
+        assert "45s since purchase" in text
+        assert "2026-03-16T12:35:00Z" in text
+
+    async def test_purchase_stamp_propagating(self, server):
+        """purchase_stamp should show estimated ready when propagating."""
+        with patch('swarm_provenance_mcp.server.gateway_client') as mock_client:
+            mock_client.purchase_stamp.return_value = {
+                "batchID": TEST_STAMP_ID,
+                "propagationStatus": "propagating",
+                "estimatedReadyAt": "2026-03-16T12:40:00Z",
+            }
+            result = await call_tool_directly(server, "purchase_stamp", {})
+
+        text = result.content[0].text
+        assert "propagating" in text
+        assert "2026-03-16T12:40:00Z" in text
+
+    async def test_purchase_stamp_ready_immediately(self, server):
+        """purchase_stamp from pool should show ready immediately."""
+        with patch('swarm_provenance_mcp.server.gateway_client') as mock_client:
+            mock_client.purchase_stamp.return_value = {
+                "batchID": TEST_STAMP_ID,
+                "propagationStatus": "ready",
+            }
+            result = await call_tool_directly(server, "purchase_stamp", {})
+
+        text = result.content[0].text
+        assert "ready immediately" in text
+
+
+class TestStampAccessMode:
+    """Test that list_stamps surfaces accessMode and propagationStatus from gateway."""
+
+    @pytest.fixture
+    def server(self):
+        return create_server()
+
+    async def test_list_stamps_shows_access_mode_owned(self, server):
+        """Stamp with accessMode 'owned' should display 'owned' in output."""
+        with patch('swarm_provenance_mcp.server.gateway_client') as mock_client:
+            mock_client.list_stamps.return_value = {
+                "stamps": [
+                    {
+                        "batchID": TEST_STAMP_ID,
+                        "usable": True,
+                        "accessMode": "owned",
+                    }
+                ],
+                "total_count": 1,
+            }
+            result = await call_tool_directly(server, "list_stamps", {})
+
+        text = result.content[0].text
+        assert "Access: owned" in text
+        assert "network-visible" not in text
+
+    async def test_list_stamps_shows_access_mode_shared(self, server):
+        """Stamp with accessMode 'shared' should display 'shared' in output."""
+        with patch('swarm_provenance_mcp.server.gateway_client') as mock_client:
+            mock_client.list_stamps.return_value = {
+                "stamps": [
+                    {
+                        "batchID": TEST_STAMP_ID,
+                        "usable": True,
+                        "accessMode": "shared",
+                    }
+                ],
+                "total_count": 1,
+            }
+            result = await call_tool_directly(server, "list_stamps", {})
+
+        text = result.content[0].text
+        assert "Access: shared" in text
+
+    async def test_list_stamps_propagation_status(self, server):
+        """Stamp with propagationStatus should display it in output."""
+        with patch('swarm_provenance_mcp.server.gateway_client') as mock_client:
+            mock_client.list_stamps.return_value = {
+                "stamps": [
+                    {
+                        "batchID": TEST_STAMP_ID,
+                        "usable": False,
+                        "accessMode": "owned",
+                        "propagationStatus": "propagating",
+                    }
+                ],
+                "total_count": 1,
+            }
+            result = await call_tool_directly(server, "list_stamps", {})
+
+        text = result.content[0].text
+        assert "Propagation: propagating" in text
+
+    async def test_list_stamps_public_only_hint(self, server):
+        """When all stamps are shared (public), show guidance about dedicated stamps."""
+        with patch('swarm_provenance_mcp.server.gateway_client') as mock_client:
+            mock_client.list_stamps.return_value = {
+                "stamps": [
+                    {
+                        "batchID": TEST_STAMP_ID,
+                        "usable": True,
+                        "accessMode": "shared",
+                    },
+                    {
+                        "batchID": "c" * 64,
+                        "usable": True,
+                        "accessMode": "shared",
+                    },
+                ],
+                "total_count": 2,
+            }
+            result = await call_tool_directly(server, "list_stamps", {})
+
+        text = result.content[0].text
+        assert "All stamps are public (shared)" in text
+        assert "dedicated stamps" in text
+
+    async def test_list_stamps_owned_no_public_hint(self, server):
+        """When at least one stamp is owned, do NOT show the public-only hint."""
+        with patch('swarm_provenance_mcp.server.gateway_client') as mock_client:
+            mock_client.list_stamps.return_value = {
+                "stamps": [
+                    {
+                        "batchID": TEST_STAMP_ID,
+                        "usable": True,
+                        "accessMode": "owned",
+                    },
+                    {
+                        "batchID": "c" * 64,
+                        "usable": True,
+                        "accessMode": "shared",
+                    },
+                ],
+                "total_count": 2,
+            }
+            result = await call_tool_directly(server, "list_stamps", {})
+
+        text = result.content[0].text
+        assert "All stamps are public" not in text
 
 
 class TestStructuredErrors:
@@ -2900,6 +3137,43 @@ class TestGetProvenanceChain:
         assert "_related:" in text
         assert "record_transform" in text
 
+    async def test_chain_from_leaf_node(self, server):
+        """Querying from leaf should return multi-entry chain via reverse traversal."""
+        parent_hash = "aa" * 32
+        leaf_hash = "bb" * 32
+
+        mock_t = MagicMock()
+        mock_t.description = "Step 1"
+        mock_t.new_data_hash = leaf_hash
+
+        mock_client = MagicMock()
+        # chain_client returns both parent and leaf when queried from leaf
+        mock_client.get_provenance_chain.return_value = [
+            self._mock_record(
+                data_hash=leaf_hash, data_hash_val=leaf_hash,
+                data_type="derived",
+            ),
+            self._mock_record(
+                data_hash=parent_hash, data_hash_val=parent_hash,
+                data_type="original", transformations=[mock_t],
+            ),
+        ]
+
+        with patch('swarm_provenance_mcp.server.CHAIN_AVAILABLE', True), \
+             patch('swarm_provenance_mcp.server.chain_client', mock_client):
+            result = await call_tool_directly(server, "get_provenance_chain", {
+                "swarm_hash": leaf_hash,
+            })
+
+        assert not result.isError
+        text = result.content[0].text
+        assert "2 entries" in text
+        assert leaf_hash in text
+        assert parent_hash in text
+        mock_client.get_provenance_chain.assert_called_once_with(
+            leaf_hash, max_depth=10
+        )
+
     async def test_chain_timestamp_zero(self, server):
         """Timestamp=0 should display as 'unknown'."""
         mock_client = MagicMock()
@@ -3284,6 +3558,64 @@ class TestGetTransformationsFrom:
         assert call_kwargs.kwargs["to_block"] == 50000
 
 
+class TestGetTransformationsTo:
+    """Test contract.get_transformations_to reverse event query."""
+
+    def test_returns_event_tuples(self):
+        from swarm_provenance_mcp.chain.contract import DataProvenanceContract
+
+        contract = DataProvenanceContract.__new__(DataProvenanceContract)
+        contract._web3 = MagicMock()
+        contract._web3.eth.block_number = 10000
+        contract._contract = MagicMock()
+
+        mock_event = MagicMock()
+        mock_event.args.originalDataHash = b'\xab' * 32
+        mock_event.args.newDataHash = b'\xcd' * 32
+        mock_event.args.transformation = "Anonymized"
+
+        contract._contract.events.DataTransformed.get_logs.return_value = [mock_event]
+
+        results = contract.get_transformations_to("cd" * 32)
+
+        assert len(results) == 1
+        orig, new, desc = results[0]
+        assert orig == b'\xab' * 32
+        assert new == b'\xcd' * 32
+        assert desc == "Anonymized"
+
+        # Verify filter used newDataHash, not originalDataHash
+        call_kwargs = contract._contract.events.DataTransformed.get_logs.call_args
+        assert "newDataHash" in call_kwargs.kwargs["argument_filters"]
+
+    def test_empty_events(self):
+        from swarm_provenance_mcp.chain.contract import DataProvenanceContract
+
+        contract = DataProvenanceContract.__new__(DataProvenanceContract)
+        contract._web3 = MagicMock()
+        contract._web3.eth.block_number = 10000
+        contract._contract = MagicMock()
+        contract._contract.events.DataTransformed.get_logs.return_value = []
+
+        results = contract.get_transformations_to("cd" * 32)
+        assert results == []
+
+    def test_lookback_blocks_calculation(self):
+        from swarm_provenance_mcp.chain.contract import DataProvenanceContract
+
+        contract = DataProvenanceContract.__new__(DataProvenanceContract)
+        contract._web3 = MagicMock()
+        contract._web3.eth.block_number = 100
+        contract._contract = MagicMock()
+        contract._contract.events.DataTransformed.get_logs.return_value = []
+
+        contract.get_transformations_to("cd" * 32, lookback_blocks=5000)
+
+        call_kwargs = contract._contract.events.DataTransformed.get_logs.call_args
+        assert call_kwargs.kwargs["from_block"] == 0
+        assert call_kwargs.kwargs["to_block"] == 100
+
+
 class TestProvenanceChainEventTraversal:
     """Test that get_provenance_chain uses events to follow transformation links."""
 
@@ -3336,6 +3668,7 @@ class TestProvenanceChainEventTraversal:
         client._contract = MagicMock()
         # Event query fails
         client._contract.get_transformations_from.side_effect = Exception("RPC error")
+        client._contract.get_transformations_to.side_effect = Exception("RPC error")
 
         record = ChainProvenanceRecord(
             data_hash="aa" * 32,
@@ -3360,6 +3693,70 @@ class TestProvenanceChainEventTraversal:
         # Should still include the first record (bb*32 not found but attempted)
         assert len(chain) == 1
         assert chain[0].data_hash == "aa" * 32
+
+    async def test_chain_from_leaf_walks_backward(self):
+        """Querying a leaf node should walk backward to find parents."""
+        from swarm_provenance_mcp.chain.client import ChainClient
+        from swarm_provenance_mcp.chain.exceptions import DataNotRegisteredError
+        from swarm_provenance_mcp.chain.models import (
+            ChainProvenanceRecord, ChainTransformation, DataStatusEnum,
+        )
+
+        client = ChainClient.__new__(ChainClient)
+        client._contract = MagicMock()
+
+        parent_hash = "aa" * 32
+        leaf_hash = "bb" * 32
+
+        parent_record = ChainProvenanceRecord(
+            data_hash=parent_hash,
+            owner="0xOWNER",
+            timestamp=1700000000,
+            data_type="original",
+            status=DataStatusEnum(0),
+            transformations=[],
+            accessors=[],
+        )
+        leaf_record = ChainProvenanceRecord(
+            data_hash=leaf_hash,
+            owner="0xOWNER",
+            timestamp=1700001000,
+            data_type="derived",
+            status=DataStatusEnum(0),
+            transformations=[],
+            accessors=[],
+        )
+
+        def get_side_effect(h):
+            if h == parent_hash:
+                return parent_record
+            if h == leaf_hash:
+                return leaf_record
+            raise DataNotRegisteredError("not found", data_hash=h)
+
+        client.get = MagicMock(side_effect=get_side_effect)
+
+        # Forward: leaf has no children
+        def fwd_side_effect(h):
+            return []
+        client._contract.get_transformations_from = MagicMock(
+            side_effect=fwd_side_effect
+        )
+
+        # Reverse: leaf was produced from parent
+        def rev_side_effect(h):
+            if h == leaf_hash:
+                return [(bytes.fromhex(parent_hash), bytes.fromhex(leaf_hash), "Step 1")]
+            return []
+        client._contract.get_transformations_to = MagicMock(
+            side_effect=rev_side_effect
+        )
+
+        chain = client.get_provenance_chain(leaf_hash)
+        hashes = [r.data_hash for r in chain]
+        assert len(chain) == 2
+        assert leaf_hash in hashes
+        assert parent_hash in hashes
 
 
 class TestProvenanceChainWorkflowPrompt:


### PR DESCRIPTION
## Summary

- Explain stamp ownership model: owned (dedicated) vs public (shared), free tier vs wallet
- Add STAMP OWNERSHIP section to MCP agent instructions
- Show guidance hint in list_stamps when all stamps are public
- Fix get_provenance_chain: add reverse event traversal so leaf-node queries walk backward to root
- Add stamp propagation timing signals to purchase_stamp, list_stamps, check_stamp_health
- Update stamp-management prompt with ownership context
- Add glossary entries for owned/public stamps
- Update CLAUDE.md, SKILLS.md, MCP_usage_ecosystem.md docs

## Closes

- Closes #96 — get_provenance_chain only returns 1 node from leaf (reverse traversal added)
- Closes #98 — list_stamps ownership filtering (accessMode surfaced, public-only hint added)
- Closes #99 — stamp propagation timing signals

## Test plan

- [x] `pytest --ignore=tests/test_end_to_end_workflow.py -v` — 403 passed
- [x] `ruff check swarm_provenance_mcp/` — no new issues
- [x] New tests: `test_list_stamps_public_only_hint`, `test_list_stamps_owned_no_public_hint`