### PR TITLE
Merge development: chain timeout, lookback, and RPC fallback fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,8 @@ CHAIN_ENABLED=false
 # Default RPC is https://sepolia.base.org (public, no API key needed).
 # Override only if you have a private Alchemy/Infura endpoint:
 # CHAIN_RPC_URL=https://base-sepolia.g.alchemy.com/v2/YOUR_KEY
+# Fallback RPCs (comma-separated, tried in order after CHAIN_RPC_URL):
+# CHAIN_RPC_URLS=https://base-sepolia-rpc.publicnode.com,https://base-sepolia.drpc.org
 # CHAIN_CONTRACT=0x9a3c6F47B69211F05891CCb7aD33596290b9fE64
 # CHAIN_EXPLORER_URL=https://sepolia.basescan.org
 # CHAIN_GAS_LIMIT=500000

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,7 @@ Blockchain dependencies (web3, eth-account) are included in the default install.
 - `CHAIN_NAME`: Blockchain network (`base-sepolia` or `base`, default: `base-sepolia`)
 - `PROVENANCE_WALLET_KEY`: Private key for chain transactions (hex, with or without 0x)
 - `CHAIN_RPC_URL`: Custom RPC endpoint (uses chain preset if not set)
+- `CHAIN_RPC_URLS`: Comma-separated fallback RPC URLs, tried in order after `CHAIN_RPC_URL`
 - `CHAIN_CONTRACT`: Custom DataProvenance contract address (uses chain preset if not set)
 - `CHAIN_EXPLORER_URL`: Custom block explorer URL (uses chain preset if not set)
 - `CHAIN_GAS_LIMIT`: Explicit gas limit for chain transactions (skips estimation if set)

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Environment variables (set in `.env` file):
 - `CHAIN_NAME`: Blockchain network — `base-sepolia` (testnet) or `base` (mainnet) (default: `base-sepolia`)
 - `PROVENANCE_WALLET_KEY`: Private key for chain transactions (hex, with or without 0x prefix)
 - `CHAIN_RPC_URL`: Custom RPC endpoint (uses chain preset if not set)
+- `CHAIN_RPC_URLS`: Comma-separated fallback RPC URLs, tried in order after `CHAIN_RPC_URL`
 - `CHAIN_CONTRACT`: Custom DataProvenance contract address (uses chain preset if not set)
 - `CHAIN_EXPLORER_URL`: Custom block explorer URL (uses chain preset if not set)
 - `CHAIN_GAS_LIMIT`: Explicit gas limit for chain transactions (skips estimation if set)

--- a/swarm_provenance_mcp/chain/client.py
+++ b/swarm_provenance_mcp/chain/client.py
@@ -48,6 +48,7 @@ class ChainClient:
         gas_limit_multiplier: float = 1.2,
         explorer_url: Optional[str] = None,
         gas_limit: Optional[int] = None,
+        rpc_fallbacks: Optional[List[str]] = None,
     ):
         """
         Initialize the chain client.
@@ -61,6 +62,7 @@ class ChainClient:
             gas_limit_multiplier: Safety multiplier for gas estimates (default 1.2).
             explorer_url: Custom block explorer URL. If None, uses preset.
             gas_limit: Explicit gas limit. If set, skips estimation and multiplier.
+            rpc_fallbacks: Fallback RPC URLs tried in order on failure.
 
         Raises:
             ChainConfigurationError: If dependencies missing or config invalid.
@@ -74,6 +76,7 @@ class ChainClient:
             rpc_url=rpc_url,
             contract_address=contract_address,
             explorer_url=explorer_url,
+            rpc_fallbacks=rpc_fallbacks,
         )
         self._wallet = ChainWallet(
             private_key=private_key,
@@ -789,9 +792,7 @@ class ChainClient:
                     if orig_hash not in visited:
                         to_visit.append((orig_hash, current_depth + 1))
             except Exception:
-                logger.debug(
-                    "Could not query reverse events for %s", current_hash
-                )
+                logger.debug("Could not query reverse events for %s", current_hash)
 
             chain.append(record)
 

--- a/swarm_provenance_mcp/chain/contract.py
+++ b/swarm_provenance_mcp/chain/contract.py
@@ -580,7 +580,7 @@ class DataProvenanceContract:
     def get_transformations_from(
         self,
         data_hash: str,
-        lookback_blocks: int = 5_000,
+        lookback_blocks: int = 50_000,
     ) -> List[Tuple[bytes, bytes, str]]:
         """
         Query DataTransformed events where data_hash is the original.
@@ -604,17 +604,19 @@ class DataProvenanceContract:
         )
         results = []
         for evt in events:
-            results.append((
-                evt.args.originalDataHash,
-                evt.args.newDataHash,
-                evt.args.transformation,
-            ))
+            results.append(
+                (
+                    evt.args.originalDataHash,
+                    evt.args.newDataHash,
+                    evt.args.transformation,
+                )
+            )
         return results
 
     def get_transformations_to(
         self,
         data_hash: str,
-        lookback_blocks: int = 5_000,
+        lookback_blocks: int = 50_000,
     ) -> List[Tuple[bytes, bytes, str]]:
         """
         Query DataTransformed events where data_hash is the new (reverse lookup).
@@ -622,6 +624,8 @@ class DataProvenanceContract:
         Args:
             data_hash: 64-char hex hash.
             lookback_blocks: How many blocks to scan backwards from latest.
+                Default 50,000 (~28h on Base at 2s/block). Public RPCs
+                reject very large ranges.
 
         Returns:
             List of (originalDataHash, newDataHash, description) tuples.
@@ -636,11 +640,13 @@ class DataProvenanceContract:
         )
         results = []
         for evt in events:
-            results.append((
-                evt.args.originalDataHash,
-                evt.args.newDataHash,
-                evt.args.transformation,
-            ))
+            results.append(
+                (
+                    evt.args.originalDataHash,
+                    evt.args.newDataHash,
+                    evt.args.transformation,
+                )
+            )
         return results
 
     # --- Gas estimation ---

--- a/swarm_provenance_mcp/chain/provider.py
+++ b/swarm_provenance_mcp/chain/provider.py
@@ -7,9 +7,12 @@ for interacting with the DataProvenance smart contract.
 Dependencies (web3, eth-account) are included in the default install.
 """
 
-from typing import Optional
+import logging
+from typing import List, Optional
 
 from .exceptions import ChainConfigurationError, ChainConnectionError
+
+logger = logging.getLogger(__name__)
 
 # Lazy web3 import
 _Web3 = None
@@ -37,12 +40,20 @@ CHAIN_PRESETS = {
         "rpc_url": "https://sepolia.base.org",
         "explorer_url": "https://sepolia.basescan.org",
         "contract_address": "0x9a3c6F47B69211F05891CCb7aD33596290b9fE64",
+        "rpc_fallbacks": [
+            "https://base-sepolia-rpc.publicnode.com",
+            "https://base-sepolia.drpc.org",
+        ],
     },
     "base": {
         "chain_id": 8453,
         "rpc_url": "https://mainnet.base.org",
         "explorer_url": "https://basescan.org",
         "contract_address": None,  # Not yet deployed
+        "rpc_fallbacks": [
+            "https://base-rpc.publicnode.com",
+            "https://base.drpc.org",
+        ],
     },
 }
 
@@ -62,6 +73,8 @@ class ChainProvider:
         rpc_url: Optional[str] = None,
         contract_address: Optional[str] = None,
         explorer_url: Optional[str] = None,
+        rpc_fallbacks: Optional[List[str]] = None,
+        request_timeout: int = 30,
     ):
         """
         Initialize the chain provider.
@@ -71,6 +84,9 @@ class ChainProvider:
             rpc_url: Custom RPC URL. If None, uses preset for chain.
             contract_address: Custom contract address. If None, uses preset.
             explorer_url: Custom block explorer URL. If None, uses preset.
+            rpc_fallbacks: Fallback RPC URLs tried in order on failure.
+                If None and no custom rpc_url, uses preset fallbacks.
+            request_timeout: HTTP request timeout in seconds (default 30).
 
         Raises:
             ChainConfigurationError: If chain is unsupported or web3 not installed.
@@ -88,6 +104,18 @@ class ChainProvider:
         self.explorer_url = explorer_url or preset["explorer_url"]
         self.contract_address = contract_address or preset["contract_address"]
         self._custom_rpc = rpc_url is not None
+        self._request_timeout = request_timeout
+
+        # Build ordered list of RPC URLs to try
+        if rpc_fallbacks is not None:
+            # Explicit fallbacks provided — use them regardless of custom RPC
+            self._rpc_urls = [self.rpc_url] + list(rpc_fallbacks)
+        elif not self._custom_rpc:
+            # No custom RPC — use preset fallbacks
+            self._rpc_urls = [self.rpc_url] + preset.get("rpc_fallbacks", [])
+        else:
+            # Custom RPC with no explicit fallbacks — primary only
+            self._rpc_urls = [self.rpc_url]
 
         if not self.contract_address:
             raise ChainConfigurationError(
@@ -96,7 +124,12 @@ class ChainProvider:
             )
 
         # Initialize Web3 connection
-        self._web3 = Web3(Web3.HTTPProvider(self.rpc_url))
+        self._web3 = Web3(
+            Web3.HTTPProvider(
+                self.rpc_url,
+                request_kwargs={"timeout": self._request_timeout},
+            )
+        )
 
         # When a custom RPC is provided, auto-detect chain ID from the node
         # (e.g. local Hardhat uses chain ID 31337, not the preset chain ID)
@@ -113,6 +146,42 @@ class ChainProvider:
         """Get the Web3 instance."""
         return self._web3
 
+    def _try_fallback(self) -> bool:
+        """
+        Try fallback RPC URLs when the current one fails.
+
+        Iterates through remaining URLs in ``_rpc_urls`` (skipping the
+        current ``rpc_url``), attempts ``is_connected()``, and switches
+        ``_web3`` and ``rpc_url`` on the first success.
+
+        Returns:
+            True if a working fallback was found and switched to.
+        """
+        Web3 = _import_web3()
+
+        for url in self._rpc_urls:
+            if url == self.rpc_url:
+                continue
+            try:
+                candidate = Web3(
+                    Web3.HTTPProvider(
+                        url,
+                        request_kwargs={"timeout": self._request_timeout},
+                    )
+                )
+                if candidate.is_connected():
+                    logger.info(
+                        "RPC fallback: switched from %s to %s",
+                        self.rpc_url,
+                        url,
+                    )
+                    self._web3 = candidate
+                    self.rpc_url = url
+                    return True
+            except Exception:
+                continue
+        return False
+
     def health_check(self) -> bool:
         """
         Check if the RPC endpoint is reachable and responding.
@@ -121,7 +190,7 @@ class ChainProvider:
             True if connected and chain ID matches.
 
         Raises:
-            ChainConnectionError: If connection fails.
+            ChainConnectionError: If connection fails (after trying fallbacks).
         """
         try:
             if not self._web3.is_connected():
@@ -137,8 +206,12 @@ class ChainProvider:
                 )
             return True
         except ChainConnectionError:
+            if self._try_fallback():
+                return self.health_check()
             raise
         except Exception as e:
+            if self._try_fallback():
+                return self.health_check()
             raise ChainConnectionError(
                 f"RPC health check failed: {e}",
                 rpc_url=self.rpc_url,
@@ -152,11 +225,13 @@ class ChainProvider:
             The current block number.
 
         Raises:
-            ChainConnectionError: If RPC call fails.
+            ChainConnectionError: If RPC call fails (after trying fallbacks).
         """
         try:
             return self._web3.eth.block_number
         except Exception as e:
+            if self._try_fallback():
+                return self.get_block_number()
             raise ChainConnectionError(
                 f"Failed to get block number: {e}",
                 rpc_url=self.rpc_url,

--- a/swarm_provenance_mcp/config.py
+++ b/swarm_provenance_mcp/config.py
@@ -74,6 +74,12 @@ class Settings(BaseSettings):
         description="Custom RPC endpoint URL (uses chain preset if not set)",
     )
 
+    chain_rpc_urls: Optional[str] = Field(
+        default=None,
+        env="CHAIN_RPC_URLS",
+        description="Comma-separated fallback RPC URLs, tried in order after CHAIN_RPC_URL",
+    )
+
     chain_contract_address: Optional[str] = Field(
         default=None,
         env="CHAIN_CONTRACT",

--- a/swarm_provenance_mcp/server.py
+++ b/swarm_provenance_mcp/server.py
@@ -40,6 +40,14 @@ gateway_client = SwarmGatewayClient()
 chain_client = None
 CHAIN_AVAILABLE = False
 
+
+def _parse_rpc_fallbacks():
+    """Parse CHAIN_RPC_URLS into a list of fallback URLs, or None."""
+    if settings.chain_rpc_urls:
+        return [u.strip() for u in settings.chain_rpc_urls.split(",") if u.strip()]
+    return None
+
+
 if settings.chain_enabled:
     try:
         from .chain import CHAIN_AVAILABLE as _chain_avail, ChainClient
@@ -53,6 +61,7 @@ if settings.chain_enabled:
                 private_key=settings.provenance_wallet_key,
                 explorer_url=settings.chain_explorer_url,
                 gas_limit=settings.chain_gas_limit,
+                rpc_fallbacks=_parse_rpc_fallbacks(),
             )
             logger.info(
                 "Chain client initialized: chain=%s contract=%s",
@@ -76,6 +85,7 @@ if settings.chain_enabled:
             )
         else:
             logger.warning("Chain client init failed: %s", e)
+
 
 def _load_skills_content() -> str:
     """Load SKILLS.md from repository root for the provenance://skills resource."""
@@ -955,7 +965,7 @@ def create_server() -> Server:
                     f"9. CRITICAL: Do NOT call anchor_hash on the new hash. "
                     f"record_transform registers it automatically.\n"
                     f"10. Call record_transform with original_hash (from step 5), "
-                    f"new_hash (from step 8), and description: \"{transform_desc}\"\n"
+                    f'new_hash (from step 8), and description: "{transform_desc}"\n'
                     f"11. Call get_provenance_chain on the original hash to verify the lineage"
                 )
 
@@ -990,7 +1000,9 @@ def create_server() -> Server:
     async def read_resource(uri) -> list[ReadResourceContents]:
         """Return resource content by URI."""
         if str(uri) == "provenance://skills":
-            return [ReadResourceContents(content=_SKILLS_CONTENT, mime_type="text/markdown")]
+            return [
+                ReadResourceContents(content=_SKILLS_CONTENT, mime_type="text/markdown")
+            ]
         raise ValueError(f"Unknown resource: {uri}")
 
     return server
@@ -1055,12 +1067,18 @@ async def handle_purchase_stamp(arguments: Dict[str, Any]) -> CallToolResult:
         if propagation_status == "ready":
             response_text += "⏱️  Stamp is ready immediately (from the gateway pool).\n"
         elif propagation_status == "propagating" and estimated_ready:
-            response_text += f"⏱️  Stamp is propagating — estimated ready at {estimated_ready}.\n"
-            response_text += "   → Use check_stamp_health to confirm it's ready before uploading."
+            response_text += (
+                f"⏱️  Stamp is propagating — estimated ready at {estimated_ready}.\n"
+            )
+            response_text += (
+                "   → Use check_stamp_health to confirm it's ready before uploading."
+            )
         else:
             response_text += "⏱️  Your stamp may be ready immediately (from the gateway pool) or may need\n"
             response_text += "   up to 2 minutes to propagate on the blockchain.\n"
-            response_text += "   → Use check_stamp_health to confirm it's ready before uploading."
+            response_text += (
+                "   → Use check_stamp_health to confirm it's ready before uploading."
+            )
         response_text += _format_hints(
             "check_stamp_health", ["get_stamp_status", "upload_data", "list_stamps"]
         )
@@ -1902,7 +1920,7 @@ async def handle_chain_balance(arguments: Dict[str, Any]) -> CallToolResult:
         )
 
     try:
-        wallet_info = chain_client.balance()
+        wallet_info = await asyncio.to_thread(chain_client.balance)
 
         response_text = f"⛓️  Chain Wallet Balance\n\n"
         response_text += f"   Wallet: {wallet_info.address}\n"
@@ -1963,13 +1981,14 @@ async def handle_chain_health(arguments: Dict[str, Any]) -> CallToolResult:
                 rpc_url=settings.chain_rpc_url,
                 contract_address=settings.chain_contract_address,
                 explorer_url=settings.chain_explorer_url,
+                rpc_fallbacks=_parse_rpc_fallbacks(),
             )
 
         start = time.monotonic()
-        provider.health_check()
+        await asyncio.to_thread(provider.health_check)
         elapsed_ms = (time.monotonic() - start) * 1000
 
-        block_number = provider.get_block_number()
+        block_number = await asyncio.to_thread(provider.get_block_number)
 
         response_text = f"⛓️  Chain RPC Health\n\n"
         response_text += f"   Connected: true\n"
@@ -2056,9 +2075,11 @@ async def handle_anchor_hash(arguments: Dict[str, Any]) -> CallToolResult:
         owner = arguments.get("owner")
 
         if owner:
-            result = chain_client.anchor_for(clean_hash, owner, data_type)
+            result = await asyncio.to_thread(
+                chain_client.anchor_for, clean_hash, owner, data_type
+            )
         else:
-            result = chain_client.anchor(clean_hash, data_type)
+            result = await asyncio.to_thread(chain_client.anchor, clean_hash, data_type)
 
         response_text = f"⛓️  Hash anchored on-chain\n\n"
         response_text += f"   Swarm Hash: {result.swarm_hash}\n"
@@ -2072,7 +2093,7 @@ async def handle_anchor_hash(arguments: Dict[str, Any]) -> CallToolResult:
 
         # Post-tx balance check
         try:
-            wallet_info = chain_client.balance()
+            wallet_info = await asyncio.to_thread(chain_client.balance)
             guidance = _format_funding_guidance(
                 wallet_info.address, wallet_info.balance_wei, wallet_info.chain
             )
@@ -2249,9 +2270,9 @@ async def handle_verify_hash(arguments: Dict[str, Any]) -> CallToolResult:
 
         # Use chain_client if available, otherwise create temporary provider + contract
         if chain_client:
-            is_registered = chain_client.verify(clean_hash)
+            is_registered = await asyncio.to_thread(chain_client.verify, clean_hash)
             if is_registered:
-                record = chain_client.get(clean_hash)
+                record = await asyncio.to_thread(chain_client.get, clean_hash)
             else:
                 record = None
         else:
@@ -2264,12 +2285,13 @@ async def handle_verify_hash(arguments: Dict[str, Any]) -> CallToolResult:
                 rpc_url=settings.chain_rpc_url,
                 contract_address=settings.chain_contract_address,
                 explorer_url=settings.chain_explorer_url,
+                rpc_fallbacks=_parse_rpc_fallbacks(),
             )
             contract = DataProvenanceContract(
                 web3=provider.web3,
                 contract_address=provider.contract_address,
             )
-            raw = contract.get_data_record(clean_hash)
+            raw = await asyncio.to_thread(contract.get_data_record, clean_hash)
             zero_address = "0x" + "0" * 40
             if raw[1] == zero_address:
                 is_registered = False
@@ -2386,7 +2408,7 @@ async def handle_get_provenance(arguments: Dict[str, Any]) -> CallToolResult:
 
         # Use chain_client if available, otherwise create temporary provider + contract
         if chain_client:
-            record = chain_client.get(clean_hash)
+            record = await asyncio.to_thread(chain_client.get, clean_hash)
         else:
             from .chain.provider import ChainProvider
             from .chain.contract import DataProvenanceContract
@@ -2402,12 +2424,13 @@ async def handle_get_provenance(arguments: Dict[str, Any]) -> CallToolResult:
                 rpc_url=settings.chain_rpc_url,
                 contract_address=settings.chain_contract_address,
                 explorer_url=settings.chain_explorer_url,
+                rpc_fallbacks=_parse_rpc_fallbacks(),
             )
             contract = DataProvenanceContract(
                 web3=provider.web3,
                 contract_address=provider.contract_address,
             )
-            raw = contract.get_data_record(clean_hash)
+            raw = await asyncio.to_thread(contract.get_data_record, clean_hash)
             zero_address = "0x" + "0" * 40
             if raw[1] == zero_address:
                 raise DataNotRegisteredError(
@@ -2572,7 +2595,9 @@ async def handle_record_transform(arguments: Dict[str, Any]) -> CallToolResult:
 
         restrict_original = arguments.get("restrict_original", False)
 
-        result = chain_client.transform(clean_original, clean_new, description)
+        result = await asyncio.to_thread(
+            chain_client.transform, clean_original, clean_new, description
+        )
 
         response_text = f"⛓️  Transformation recorded on-chain\n\n"
         response_text += f"   Original: {result.original_hash}\n"
@@ -2588,7 +2613,9 @@ async def handle_record_transform(arguments: Dict[str, Any]) -> CallToolResult:
         # Optionally restrict the original data after transformation
         if restrict_original:
             try:
-                chain_client.set_status(clean_original, 1)  # 1 = RESTRICTED
+                await asyncio.to_thread(
+                    chain_client.set_status, clean_original, 1
+                )  # 1 = RESTRICTED
                 response_text += f"\n\n   ⚠️  Original data status set to RESTRICTED"
             except Exception as restrict_err:
                 response_text += (
@@ -2598,7 +2625,7 @@ async def handle_record_transform(arguments: Dict[str, Any]) -> CallToolResult:
 
         # Post-tx balance check
         try:
-            wallet_info = chain_client.balance()
+            wallet_info = await asyncio.to_thread(chain_client.balance)
             guidance = _format_funding_guidance(
                 wallet_info.address, wallet_info.balance_wei, wallet_info.chain
             )
@@ -2658,9 +2685,7 @@ async def handle_record_transform(arguments: Dict[str, Any]) -> CallToolResult:
 
         if isinstance(e, ChainTransactionError):
             if _is_insufficient_funds_error(e):
-                msg = _format_insufficient_funds_error(
-                    "record_transform", chain_client
-                )
+                msg = _format_insufficient_funds_error("record_transform", chain_client)
             else:
                 msg = f"Transaction failed: {str(e)}"
                 if e.tx_hash:
@@ -2708,9 +2733,7 @@ async def handle_record_transform(arguments: Dict[str, Any]) -> CallToolResult:
 
         # Catch-all: still check for insufficient funds in generic errors
         if _is_insufficient_funds_error(e):
-            msg = _format_insufficient_funds_error(
-                "record_transform", chain_client
-            )
+            msg = _format_insufficient_funds_error("record_transform", chain_client)
             return CallToolResult(
                 content=[
                     TextContent(
@@ -2766,8 +2789,10 @@ async def handle_get_provenance_chain(arguments: Dict[str, Any]) -> CallToolResu
             raise ValueError("max_depth must be an integer between 1 and 50")
 
         if chain_client:
-            chain_records = chain_client.get_provenance_chain(
-                clean_hash, max_depth=max_depth
+            chain_records = await asyncio.to_thread(
+                lambda: chain_client.get_provenance_chain(
+                    clean_hash, max_depth=max_depth
+                )
             )
         else:
             # Read-only fallback without wallet key
@@ -2785,87 +2810,94 @@ async def handle_get_provenance_chain(arguments: Dict[str, Any]) -> CallToolResu
                 rpc_url=settings.chain_rpc_url,
                 contract_address=settings.chain_contract_address,
                 explorer_url=settings.chain_explorer_url,
+                rpc_fallbacks=_parse_rpc_fallbacks(),
             )
             contract = DataProvenanceContract(
                 web3=provider.web3,
                 contract_address=provider.contract_address,
             )
 
-            # Manual traversal mirroring ChainClient.get_provenance_chain
-            chain_records = []
-            visited = set()
-            to_visit = [(clean_hash, 0)]
-            zero_address = "0x" + "0" * 40
+            def _readonly_traverse():
+                """BFS traversal in a thread to avoid blocking the event loop."""
+                records = []
+                visited = set()
+                to_visit = [(clean_hash, 0)]
+                zero_address = "0x" + "0" * 40
 
-            while to_visit:
-                current_hash, depth = to_visit.pop(0)
-                if current_hash in visited or depth > max_depth:
-                    continue
-                visited.add(current_hash)
-
-                try:
-                    raw = contract.get_data_record(current_hash)
-                    if raw[1] == zero_address:
+                while to_visit:
+                    current_hash, depth = to_visit.pop(0)
+                    if current_hash in visited or depth > max_depth:
                         continue
-                    record = ChainProvenanceRecord(
-                        data_hash=(
-                            raw[0].hex() if isinstance(raw[0], bytes) else str(raw[0])
-                        ),
-                        owner=raw[1],
-                        timestamp=raw[2],
-                        data_type=raw[3],
-                        status=DataStatusEnum(raw[6]),
-                        accessors=list(raw[5]),
-                        transformations=[
-                            ChainTransformation(description=str(t)) for t in raw[4]
-                        ],
-                    )
+                    visited.add(current_hash)
 
-                    # Enrich transformations with new_data_hash from events
                     try:
-                        events = contract.get_transformations_from(current_hash)
-                        if events:
-                            enriched = []
-                            for orig_bytes, new_bytes, desc in events:
-                                new_hash = (
-                                    new_bytes.hex()
-                                    if isinstance(new_bytes, bytes)
-                                    else str(new_bytes)
-                                )
-                                enriched.append(
-                                    ChainTransformation(
-                                        description=desc,
-                                        new_data_hash=new_hash,
-                                    )
-                                )
-                                if new_hash not in visited:
-                                    to_visit.append((new_hash, depth + 1))
-                            record.transformations = enriched
-                    except Exception:
-                        # Fall back to record.transformations (description-only)
-                        for t in record.transformations:
-                            if t.new_data_hash and t.new_data_hash not in visited:
-                                to_visit.append((t.new_data_hash, depth + 1))
-
-                    # Reverse: find parents
-                    try:
-                        reverse_events = contract.get_transformations_to(
-                            current_hash
+                        raw = contract.get_data_record(current_hash)
+                        if raw[1] == zero_address:
+                            continue
+                        record = ChainProvenanceRecord(
+                            data_hash=(
+                                raw[0].hex()
+                                if isinstance(raw[0], bytes)
+                                else str(raw[0])
+                            ),
+                            owner=raw[1],
+                            timestamp=raw[2],
+                            data_type=raw[3],
+                            status=DataStatusEnum(raw[6]),
+                            accessors=list(raw[5]),
+                            transformations=[
+                                ChainTransformation(description=str(t)) for t in raw[4]
+                            ],
                         )
-                        for orig_bytes, new_bytes, desc in reverse_events:
-                            orig_hash = (
-                                orig_bytes.hex()
-                                if isinstance(orig_bytes, bytes)
-                                else str(orig_bytes)
-                            )
-                            if orig_hash not in visited:
-                                to_visit.append((orig_hash, depth + 1))
-                    except Exception:
-                        pass
 
-                    chain_records.append(record)
-                except Exception:
-                    continue
+                        # Enrich transformations with new_data_hash from events
+                        try:
+                            events = contract.get_transformations_from(current_hash)
+                            if events:
+                                enriched = []
+                                for orig_bytes, new_bytes, desc in events:
+                                    new_hash = (
+                                        new_bytes.hex()
+                                        if isinstance(new_bytes, bytes)
+                                        else str(new_bytes)
+                                    )
+                                    enriched.append(
+                                        ChainTransformation(
+                                            description=desc,
+                                            new_data_hash=new_hash,
+                                        )
+                                    )
+                                    if new_hash not in visited:
+                                        to_visit.append((new_hash, depth + 1))
+                                record.transformations = enriched
+                        except Exception:
+                            for t in record.transformations:
+                                if t.new_data_hash and t.new_data_hash not in visited:
+                                    to_visit.append((t.new_data_hash, depth + 1))
+
+                        # Reverse: find parents
+                        try:
+                            reverse_events = contract.get_transformations_to(
+                                current_hash
+                            )
+                            for orig_bytes, new_bytes, desc in reverse_events:
+                                orig_hash = (
+                                    orig_bytes.hex()
+                                    if isinstance(orig_bytes, bytes)
+                                    else str(orig_bytes)
+                                )
+                                if orig_hash not in visited:
+                                    to_visit.append((orig_hash, depth + 1))
+                        except Exception:
+                            pass
+
+                        records.append(record)
+                    except Exception:
+                        continue
+
+                return records
+
+            chain_records = await asyncio.to_thread(_readonly_traverse)
 
         if not chain_records:
             response_text = f"⛓️  No provenance chain found\n\n"

--- a/tests/test_chain_client.py
+++ b/tests/test_chain_client.py
@@ -498,6 +498,100 @@ class TestChainProvider:
         url = provider.get_explorer_address_url(DUMMY_ADDRESS)
         assert "sepolia.basescan.org/address/" in url
 
+    def test_preset_fallbacks_used_by_default(self, mock_chain_deps):
+        """Default init should include primary + preset fallback URLs."""
+        from swarm_provenance_mcp.chain.provider import ChainProvider
+
+        provider = ChainProvider(chain="base-sepolia")
+        assert len(provider._rpc_urls) == 3
+        assert provider._rpc_urls[0] == "https://sepolia.base.org"
+        assert "publicnode.com" in provider._rpc_urls[1]
+        assert "drpc.org" in provider._rpc_urls[2]
+
+    def test_custom_rpc_skips_preset_fallbacks(self, mock_chain_deps):
+        """Custom RPC with no explicit fallbacks should only have primary."""
+        from swarm_provenance_mcp.chain.provider import ChainProvider
+
+        provider = ChainProvider(
+            chain="base-sepolia",
+            rpc_url="https://custom.rpc.io",
+        )
+        assert len(provider._rpc_urls) == 1
+        assert provider._rpc_urls[0] == "https://custom.rpc.io"
+
+    def test_explicit_fallbacks_with_custom_rpc(self, mock_chain_deps):
+        """Custom RPC + explicit fallbacks should include both."""
+        from swarm_provenance_mcp.chain.provider import ChainProvider
+
+        provider = ChainProvider(
+            chain="base-sepolia",
+            rpc_url="https://custom.rpc.io",
+            rpc_fallbacks=["https://fb1.io", "https://fb2.io"],
+        )
+        assert len(provider._rpc_urls) == 3
+        assert provider._rpc_urls[0] == "https://custom.rpc.io"
+        assert provider._rpc_urls[1] == "https://fb1.io"
+        assert provider._rpc_urls[2] == "https://fb2.io"
+
+    def test_request_timeout_applied(self, mock_chain_deps):
+        """HTTPProvider should receive the timeout kwarg."""
+        from swarm_provenance_mcp.chain.provider import ChainProvider
+
+        provider = ChainProvider(chain="base-sepolia", request_timeout=15)
+        # The Web3 class is mocked, so verify HTTPProvider was called with timeout
+        web3_cls = mock_chain_deps["web3_class"]
+        http_provider_calls = web3_cls.HTTPProvider.call_args_list
+        # Last call should have our timeout
+        last_call = http_provider_calls[-1]
+        assert last_call.kwargs.get("request_kwargs") == {"timeout": 15}
+
+    def test_health_check_tries_fallback(self, mock_chain_deps):
+        """Primary fails, fallback succeeds — provider should switch."""
+        from swarm_provenance_mcp.chain.provider import ChainProvider
+
+        provider = ChainProvider(chain="base-sepolia")
+        original_url = provider.rpc_url
+
+        # Make the current web3 fail is_connected
+        provider._web3.is_connected.return_value = False
+
+        # Mock _import_web3 to return a Web3 class whose instances succeed
+        fallback_web3 = MagicMock()
+        fallback_web3.is_connected.return_value = True
+        fallback_web3.eth.chain_id = 84532
+
+        web3_cls = mock_chain_deps["web3_class"]
+        web3_cls.return_value = fallback_web3
+
+        result = provider.health_check()
+        assert result is True
+        # Provider should have switched to a fallback URL
+        assert provider.rpc_url != original_url
+        assert provider._web3 == fallback_web3
+
+    def test_get_block_number_tries_fallback(self, mock_chain_deps):
+        """get_block_number should try fallback when primary fails."""
+        from swarm_provenance_mcp.chain.provider import ChainProvider
+
+        provider = ChainProvider(chain="base-sepolia")
+
+        # Make current web3 block_number raise
+        type(provider._web3.eth).block_number = PropertyMock(
+            side_effect=Exception("RPC timeout")
+        )
+
+        # Fallback web3 returns a block number
+        fallback_web3 = MagicMock()
+        fallback_web3.is_connected.return_value = True
+        type(fallback_web3.eth).block_number = PropertyMock(return_value=99999)
+
+        web3_cls = mock_chain_deps["web3_class"]
+        web3_cls.return_value = fallback_web3
+
+        block = provider.get_block_number()
+        assert block == 99999
+        assert provider._web3 == fallback_web3
+
 
 # --- Wallet tests ---
 
@@ -594,6 +688,19 @@ class TestChainClientInit:
         # Verify explorer URL is used in anchor results
         result = client.anchor(swarm_hash=DUMMY_HASH)
         assert "custom-explorer.io" in result.explorer_url
+
+    def test_rpc_fallbacks_passthrough(self, mock_chain_deps):
+        """rpc_fallbacks should be passed through to ChainProvider."""
+        from swarm_provenance_mcp.chain.client import ChainClient
+
+        fallbacks = ["https://fb1.io", "https://fb2.io"]
+        client = ChainClient(
+            chain="base-sepolia",
+            rpc_fallbacks=fallbacks,
+        )
+        assert client._provider._rpc_urls[0] == "https://sepolia.base.org"
+        assert client._provider._rpc_urls[1] == "https://fb1.io"
+        assert client._provider._rpc_urls[2] == "https://fb2.io"
 
     def test_missing_deps_shows_helpful_message(self):
         """Tests that missing blockchain deps give clear error."""

--- a/tests/test_tool_execution.py
+++ b/tests/test_tool_execution.py
@@ -1432,6 +1432,37 @@ class TestChainHealth:
         text = result.content[0].text
         assert "Connected: false" in text
 
+    async def test_chain_health_with_fallback_urls(self, server):
+        """CHAIN_RPC_URLS config should be parsed and passed to ChainProvider."""
+        mock_provider_cls = MagicMock()
+        mock_provider_instance = MagicMock()
+        mock_provider_instance.chain = "base-sepolia"
+        mock_provider_instance.chain_id = 84532
+        mock_provider_instance.rpc_url = "https://sepolia.base.org"
+        mock_provider_instance.contract_address = "0x9a3c6F47B69211F05891CCb7aD33596290b9fE64"
+        mock_provider_instance.health_check.return_value = True
+        mock_provider_instance.get_block_number.return_value = 12345678
+        mock_provider_cls.return_value = mock_provider_instance
+
+        with patch('swarm_provenance_mcp.server.CHAIN_AVAILABLE', True), \
+             patch('swarm_provenance_mcp.server.chain_client', None), \
+             patch('swarm_provenance_mcp.server.settings') as mock_settings, \
+             patch('swarm_provenance_mcp.chain.provider.ChainProvider', mock_provider_cls):
+            mock_settings.chain_name = "base-sepolia"
+            mock_settings.chain_rpc_url = None
+            mock_settings.chain_contract_address = None
+            mock_settings.chain_explorer_url = None
+            mock_settings.chain_rpc_urls = "https://fallback1.com,https://fallback2.com"
+            result = await call_tool_directly(server, "chain_health", {})
+
+        assert not result.isError
+        # Verify ChainProvider was called with rpc_fallbacks
+        call_kwargs = mock_provider_cls.call_args
+        assert call_kwargs.kwargs["rpc_fallbacks"] == [
+            "https://fallback1.com",
+            "https://fallback2.com",
+        ]
+
 
 class TestFundingGuidance:
     """Direct unit tests for _format_funding_guidance helper."""
@@ -1489,6 +1520,62 @@ class TestFundingGuidance:
         from swarm_provenance_mcp.server import _format_funding_guidance
         result = _format_funding_guidance("0xabc", 100, "base-mainnet-custom")
         assert "bridge.base.org" in result
+
+
+class TestParseRpcFallbacks:
+    """Unit tests for _parse_rpc_fallbacks helper."""
+
+    def test_none_returns_none(self):
+        """No CHAIN_RPC_URLS setting should return None."""
+        from swarm_provenance_mcp.server import _parse_rpc_fallbacks
+
+        with patch("swarm_provenance_mcp.server.settings") as mock_settings:
+            mock_settings.chain_rpc_urls = None
+            assert _parse_rpc_fallbacks() is None
+
+    def test_empty_string_returns_none(self):
+        """Empty string should return None."""
+        from swarm_provenance_mcp.server import _parse_rpc_fallbacks
+
+        with patch("swarm_provenance_mcp.server.settings") as mock_settings:
+            mock_settings.chain_rpc_urls = ""
+            assert _parse_rpc_fallbacks() is None
+
+    def test_single_url(self):
+        """Single URL without commas."""
+        from swarm_provenance_mcp.server import _parse_rpc_fallbacks
+
+        with patch("swarm_provenance_mcp.server.settings") as mock_settings:
+            mock_settings.chain_rpc_urls = "https://fb1.io"
+            assert _parse_rpc_fallbacks() == ["https://fb1.io"]
+
+    def test_comma_separated(self):
+        """Multiple comma-separated URLs."""
+        from swarm_provenance_mcp.server import _parse_rpc_fallbacks
+
+        with patch("swarm_provenance_mcp.server.settings") as mock_settings:
+            mock_settings.chain_rpc_urls = "https://fb1.io,https://fb2.io,https://fb3.io"
+            assert _parse_rpc_fallbacks() == [
+                "https://fb1.io",
+                "https://fb2.io",
+                "https://fb3.io",
+            ]
+
+    def test_whitespace_trimmed(self):
+        """Whitespace around URLs should be stripped."""
+        from swarm_provenance_mcp.server import _parse_rpc_fallbacks
+
+        with patch("swarm_provenance_mcp.server.settings") as mock_settings:
+            mock_settings.chain_rpc_urls = " https://fb1.io , https://fb2.io "
+            assert _parse_rpc_fallbacks() == ["https://fb1.io", "https://fb2.io"]
+
+    def test_trailing_comma_ignored(self):
+        """Trailing comma should not produce an empty entry."""
+        from swarm_provenance_mcp.server import _parse_rpc_fallbacks
+
+        with patch("swarm_provenance_mcp.server.settings") as mock_settings:
+            mock_settings.chain_rpc_urls = "https://fb1.io,"
+            assert _parse_rpc_fallbacks() == ["https://fb1.io"]
 
 
 class TestMaskRpcUrl:
@@ -3557,6 +3644,22 @@ class TestGetTransformationsFrom:
         assert call_kwargs.kwargs["from_block"] == 49000
         assert call_kwargs.kwargs["to_block"] == 50000
 
+    def test_default_lookback_is_50000(self):
+        """Default lookback should be 50,000 blocks (~28h on Base)."""
+        from swarm_provenance_mcp.chain.contract import DataProvenanceContract
+
+        contract = DataProvenanceContract.__new__(DataProvenanceContract)
+        contract._web3 = MagicMock()
+        contract._web3.eth.block_number = 100_000
+        contract._contract = MagicMock()
+        contract._contract.events.DataTransformed.get_logs.return_value = []
+
+        contract.get_transformations_from("ab" * 32)
+
+        call_kwargs = contract._contract.events.DataTransformed.get_logs.call_args
+        assert call_kwargs.kwargs["from_block"] == 50_000
+        assert call_kwargs.kwargs["to_block"] == 100_000
+
 
 class TestGetTransformationsTo:
     """Test contract.get_transformations_to reverse event query."""
@@ -3614,6 +3717,22 @@ class TestGetTransformationsTo:
         call_kwargs = contract._contract.events.DataTransformed.get_logs.call_args
         assert call_kwargs.kwargs["from_block"] == 0
         assert call_kwargs.kwargs["to_block"] == 100
+
+    def test_default_lookback_is_50000(self):
+        """Default lookback should be 50,000 blocks (~28h on Base)."""
+        from swarm_provenance_mcp.chain.contract import DataProvenanceContract
+
+        contract = DataProvenanceContract.__new__(DataProvenanceContract)
+        contract._web3 = MagicMock()
+        contract._web3.eth.block_number = 100_000
+        contract._contract = MagicMock()
+        contract._contract.events.DataTransformed.get_logs.return_value = []
+
+        contract.get_transformations_to("cd" * 32)
+
+        call_kwargs = contract._contract.events.DataTransformed.get_logs.call_args
+        assert call_kwargs.kwargs["from_block"] == 50_000
+        assert call_kwargs.kwargs["to_block"] == 100_000
 
 
 class TestProvenanceChainEventTraversal:


### PR DESCRIPTION
## Summary

- **Async wrapping**: All 7 chain handlers use `asyncio.to_thread()` to prevent blocking the event loop — fixes silent MCP client timeouts (#103)
- **Lookback window**: Event query default increased from 5,000 to 50,000 blocks (~28h), matching documented intent (#104)
- **RPC fallback**: Preset fallback RPCs with automatic failover, `CHAIN_RPC_URLS` env var, 30s request timeout (#105)

## Test plan

- [x] 399 tests pass
- [x] Black / ruff clean