### PR TITLE
Add in-memory event cache for get_provenance_chain

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,7 @@ On-chain provenance module. Dependencies (web3, eth-account) included in default
 - `chain/provider.py` — Web3 RPC connection management
 - `chain/wallet.py` — Private key loading and transaction signing
 - `chain/contract.py` — DataProvenance contract wrapper (build_*_tx, read methods, event queries)
+- `chain/event_cache.py` — In-memory cache for DataTransformed events (singleton per chain+contract, incremental scans)
 - `chain/models.py` — Pydantic models (AnchorResult, ChainProvenanceRecord, etc.)
 - `chain/exceptions.py` — Standalone exception hierarchy (ChainError base)
 - `chain/abi/DataProvenance.json` — Contract ABI
@@ -180,7 +181,7 @@ The `config.py` module uses Pydantic Settings for type-safe configuration with a
 - **MCP Resources**: `provenance://skills` resource (SKILLS.md content) via `@server.list_resources()` / `@server.read_resource()`
 - **Cross-server coordination**: health_check reports companion servers (swarm_connect gateway status, fds-id MCP availability)
 - **Insufficient funds**: `_is_insufficient_funds_error()` and `_format_insufficient_funds_error()` provide faucet/bridge URLs
-- **Event-based lineage**: `get_provenance_chain` uses `DataTransformed` contract events bidirectionally (forward via `originalDataHash`, reverse via `newDataHash`) for accurate transformation traversal from any node
+- **Event-based lineage**: `get_provenance_chain` uses `DataTransformed` contract events bidirectionally (forward via `originalDataHash`, reverse via `newDataHash`) for accurate transformation traversal from any node. Events are cached in-memory (`chain/event_cache.py`): full scan on first call, incremental scans on subsequent calls (<1s vs ~20s)
 - Helper functions: `_format_hints()`, `_format_error()`, `_is_retryable_error()`, `_suggest_tool_name()`
 
 ### Code Quality

--- a/swarm_provenance_mcp/chain/client.py
+++ b/swarm_provenance_mcp/chain/client.py
@@ -713,9 +713,10 @@ class ChainClient:
         """
         Get the provenance chain for a data hash.
 
-        Retrieves the record for the given hash, then queries
-        DataTransformed events to discover linked hashes and follows
-        them to build a lineage chain.
+        Scans ALL DataTransformed events from the contract's deploy block
+        to build an in-memory index, then performs BFS traversal using
+        local lookups (no per-node event queries).  Falls back to
+        per-node event scanning when the deploy block is unknown.
 
         Args:
             swarm_hash: Starting Swarm reference hash.
@@ -730,6 +731,29 @@ class ChainClient:
         )
 
         effective_max = max_depth if max_depth is not None else 50
+
+        # Build in-memory transformation index via cached event scan.
+        # First call does a full scan; subsequent calls are incremental.
+        from .event_cache import get_cache
+
+        forward = {}  # original_hex -> [(new_hex, desc)]
+        reverse = {}  # new_hex -> [(original_hex, desc)]
+        deploy_block = self._provider.deploy_block
+
+        if deploy_block is not None:
+            try:
+                cache = get_cache(self._provider.chain, self._provider.contract_address)
+                current_block = self._provider.web3.eth.block_number
+                forward, reverse = cache.get_maps(
+                    self._contract, deploy_block, current_block
+                )
+            except Exception as e:
+                logger.warning(
+                    "Full event scan failed, falling back to per-node queries: %s", e
+                )
+                deploy_block = None  # triggers per-node fallback below
+
+        use_local_index = deploy_block is not None
 
         chain = []
         visited = set()
@@ -750,49 +774,62 @@ class ChainClient:
                 logger.debug("Hash %s not registered, skipping", current_hash)
                 continue
 
-            # Enrich transformations with new_data_hash from events
-            try:
-                events = self._contract.get_transformations_from(current_hash)
-                enriched = []
-                for orig_bytes, new_bytes, desc in events:
-                    new_hash = (
-                        new_bytes.hex()
-                        if isinstance(new_bytes, bytes)
-                        else str(new_bytes)
-                    )
-                    enriched.append(
-                        ChainTransformation(
-                            description=desc,
-                            new_data_hash=new_hash,
+            if use_local_index:
+                # Use pre-built index — no RPC calls
+                fwd = forward.get(current_hash, [])
+                if fwd:
+                    record.transformations = [
+                        ChainTransformation(description=desc, new_data_hash=nh)
+                        for nh, desc in fwd
+                    ]
+                    for nh, _ in fwd:
+                        if nh not in visited:
+                            to_visit.append((nh, current_depth + 1))
+                # Reverse links (parents)
+                for orig_hex, _ in reverse.get(current_hash, []):
+                    if orig_hex not in visited:
+                        to_visit.append((orig_hex, current_depth + 1))
+            else:
+                # Per-node event scanning (fallback when deploy_block unknown)
+                try:
+                    events = self._contract.get_transformations_from(current_hash)
+                    enriched = []
+                    for orig_bytes, new_bytes, desc in events:
+                        new_hash = (
+                            new_bytes.hex()
+                            if isinstance(new_bytes, bytes)
+                            else str(new_bytes)
                         )
-                    )
-                    if new_hash not in visited:
-                        to_visit.append((new_hash, current_depth + 1))
-                if enriched:
-                    record.transformations = enriched
-            except Exception:
-                logger.debug(
-                    "Could not query events for %s, using record data",
-                    current_hash,
-                )
-                # Fall back to record.transformations (description-only)
-                for t in record.transformations:
-                    if t.new_data_hash and t.new_data_hash not in visited:
-                        to_visit.append((t.new_data_hash, current_depth + 1))
+                        enriched.append(
+                            ChainTransformation(
+                                description=desc,
+                                new_data_hash=new_hash,
+                            )
+                        )
+                        if new_hash not in visited:
+                            to_visit.append((new_hash, current_depth + 1))
+                    if enriched:
+                        record.transformations = enriched
+                except Exception as e:
+                    logger.warning("Event query failed for %s: %s", current_hash, e)
+                    for t in record.transformations:
+                        if t.new_data_hash and t.new_data_hash not in visited:
+                            to_visit.append((t.new_data_hash, current_depth + 1))
 
-            # Reverse: transformations TO this hash (find parents)
-            try:
-                reverse_events = self._contract.get_transformations_to(current_hash)
-                for orig_bytes, new_bytes, desc in reverse_events:
-                    orig_hash = (
-                        orig_bytes.hex()
-                        if isinstance(orig_bytes, bytes)
-                        else str(orig_bytes)
+                try:
+                    reverse_events = self._contract.get_transformations_to(current_hash)
+                    for orig_bytes, new_bytes, desc in reverse_events:
+                        orig_hash = (
+                            orig_bytes.hex()
+                            if isinstance(orig_bytes, bytes)
+                            else str(orig_bytes)
+                        )
+                        if orig_hash not in visited:
+                            to_visit.append((orig_hash, current_depth + 1))
+                except Exception as e:
+                    logger.warning(
+                        "Reverse event query failed for %s: %s", current_hash, e
                     )
-                    if orig_hash not in visited:
-                        to_visit.append((orig_hash, current_depth + 1))
-            except Exception:
-                logger.debug("Could not query reverse events for %s", current_hash)
 
             chain.append(record)
 

--- a/swarm_provenance_mcp/chain/contract.py
+++ b/swarm_provenance_mcp/chain/contract.py
@@ -589,18 +589,25 @@ class DataProvenanceContract:
         Splits the range [from_block, to_block] into windows of
         ``_EVENT_CHUNK_SIZE`` and concatenates results.  On 413/payload
         errors the failing chunk is halved once before giving up.
+
+        ``argument_filters`` may be ``None`` to fetch all events of the
+        given type (unfiltered scan).
         """
         all_events = []
         start = from_block
+
+        # Build kwargs — omit argument_filters when None so web3 uses
+        # its default (no topic filtering beyond the event signature).
+        def _get(fb, tb):
+            kw = {"from_block": fb, "to_block": tb}
+            if argument_filters:
+                kw["argument_filters"] = argument_filters
+            return event.get_logs(**kw)
+
         while start <= to_block:
             end = min(start + self._EVENT_CHUNK_SIZE - 1, to_block)
             try:
-                logs = event.get_logs(
-                    argument_filters=argument_filters,
-                    from_block=start,
-                    to_block=end,
-                )
-                all_events.extend(logs)
+                all_events.extend(_get(start, end))
             except Exception as e:
                 err_str = str(e).lower()
                 if "413" in err_str or "payload" in err_str or "too large" in err_str:
@@ -609,18 +616,8 @@ class DataProvenanceContract:
                     if mid == start:
                         raise  # Can't split further
                     try:
-                        logs1 = event.get_logs(
-                            argument_filters=argument_filters,
-                            from_block=start,
-                            to_block=mid,
-                        )
-                        logs2 = event.get_logs(
-                            argument_filters=argument_filters,
-                            from_block=mid + 1,
-                            to_block=end,
-                        )
-                        all_events.extend(logs1)
-                        all_events.extend(logs2)
+                        all_events.extend(_get(start, mid))
+                        all_events.extend(_get(mid + 1, end))
                     except Exception:
                         raise  # Give up on this chunk
                 else:
@@ -701,6 +698,37 @@ class DataProvenanceContract:
                 )
             )
         return results
+
+    def get_all_transformations(
+        self,
+        from_block: int = 0,
+        to_block: int = None,
+    ) -> List[Tuple[bytes, bytes, str]]:
+        """
+        Query ALL DataTransformed events in a block range (no hash filter).
+
+        Used by ``get_provenance_chain`` to build an in-memory index of
+        all transformations, enabling BFS traversal without per-node
+        event queries.
+
+        Args:
+            from_block: Start of the scan range (e.g. contract deploy block).
+            to_block: End of the scan range. Defaults to latest block.
+
+        Returns:
+            List of (originalDataHash, newDataHash, description) tuples.
+        """
+        latest = to_block if to_block is not None else self._web3.eth.block_number
+        events = self._get_logs_chunked(
+            self._contract.events.DataTransformed,
+            None,
+            from_block,
+            latest,
+        )
+        return [
+            (evt.args.originalDataHash, evt.args.newDataHash, evt.args.transformation)
+            for evt in events
+        ]
 
     # --- Gas estimation ---
 

--- a/swarm_provenance_mcp/chain/event_cache.py
+++ b/swarm_provenance_mcp/chain/event_cache.py
@@ -1,0 +1,122 @@
+"""
+In-memory cache for DataTransformed event logs.
+
+The DataProvenance contract stores transformation descriptions (string[])
+but NOT the linked hashes in state — newDataHash is only in event logs.
+This forces get_provenance_chain to scan the full contract history on
+every call (~1.4M blocks on Base Sepolia, ~20s).
+
+This module provides a singleton cache per (chain, contract_address) that
+does a full scan on first call and incremental scans on subsequent calls,
+reducing repeat queries to <1s.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+
+logger = logging.getLogger(__name__)
+
+# Module-level singleton registry keyed by (chain, contract_address_lower)
+_registry: dict[tuple[str, str], TransformationEventCache] = {}
+_registry_lock = threading.Lock()
+
+
+class TransformationEventCache:
+    """Thread-safe in-memory cache of DataTransformed events.
+
+    Builds forward and reverse lookup maps from event logs.
+    First call does a full scan from deploy_block; subsequent calls
+    scan only new blocks since the last scan.
+    """
+
+    def __init__(self):
+        self._forward: dict[str, list[tuple[str, str]]] = {}
+        self._reverse: dict[str, list[tuple[str, str]]] = {}
+        self._last_scanned_block: int | None = None
+        self._lock = threading.Lock()
+
+    def get_maps(
+        self,
+        contract,
+        deploy_block: int,
+        current_block: int,
+    ) -> tuple[dict, dict]:
+        """Return (forward, reverse) transformation maps.
+
+        Args:
+            contract: DataProvenanceContract instance with get_all_transformations().
+            deploy_block: Contract deploy block (start of first scan).
+            current_block: Latest block number (end of scan range).
+
+        Returns:
+            Tuple of (forward, reverse) dicts:
+              forward: original_hex -> [(new_hex, description), ...]
+              reverse: new_hex -> [(original_hex, description), ...]
+
+        Raises:
+            Exception: Propagated from contract.get_all_transformations()
+                on scan failure. Caller should catch and fall back to
+                per-node event queries.
+        """
+        with self._lock:
+            if self._last_scanned_block is None:
+                from_block = deploy_block
+            else:
+                from_block = self._last_scanned_block + 1
+
+            if from_block > current_block:
+                return self._forward, self._reverse
+
+            events = contract.get_all_transformations(
+                from_block=from_block,
+                to_block=current_block,
+            )
+
+            for orig_bytes, new_bytes, desc in events:
+                orig_hex = (
+                    orig_bytes.hex()
+                    if isinstance(orig_bytes, bytes)
+                    else str(orig_bytes)
+                )
+                new_hex = (
+                    new_bytes.hex() if isinstance(new_bytes, bytes) else str(new_bytes)
+                )
+                self._forward.setdefault(orig_hex, []).append((new_hex, desc))
+                self._reverse.setdefault(new_hex, []).append((orig_hex, desc))
+
+            self._last_scanned_block = current_block
+            logger.debug(
+                "Event cache updated: scanned blocks %d-%d, "
+                "%d forward entries, %d reverse entries",
+                from_block,
+                current_block,
+                len(self._forward),
+                len(self._reverse),
+            )
+
+            return self._forward, self._reverse
+
+
+def get_cache(chain: str, contract_address: str) -> TransformationEventCache:
+    """Get or create the singleton cache for a (chain, contract) pair.
+
+    Args:
+        chain: Chain name (e.g. 'base-sepolia').
+        contract_address: Contract address (case-insensitive).
+
+    Returns:
+        TransformationEventCache instance (shared across callers).
+    """
+    key = (chain, contract_address.lower())
+    with _registry_lock:
+        if key not in _registry:
+            _registry[key] = TransformationEventCache()
+        return _registry[key]
+
+
+def clear_registry():
+    """Clear all cached instances. For testing only."""
+    with _registry_lock:
+        _registry.clear()

--- a/swarm_provenance_mcp/chain/provider.py
+++ b/swarm_provenance_mcp/chain/provider.py
@@ -40,6 +40,7 @@ CHAIN_PRESETS = {
         "rpc_url": "https://sepolia.base.org",
         "explorer_url": "https://sepolia.basescan.org",
         "contract_address": "0x9a3c6F47B69211F05891CCb7aD33596290b9fE64",
+        "deploy_block": 37_562_100,
         "rpc_fallbacks": [
             "https://base-sepolia-rpc.publicnode.com",
             "https://base-sepolia.drpc.org",
@@ -50,6 +51,7 @@ CHAIN_PRESETS = {
         "rpc_url": "https://mainnet.base.org",
         "explorer_url": "https://basescan.org",
         "contract_address": None,  # Not yet deployed
+        "deploy_block": None,
         "rpc_fallbacks": [
             "https://base-rpc.publicnode.com",
             "https://base.drpc.org",
@@ -103,6 +105,7 @@ class ChainProvider:
         self.rpc_url = rpc_url or preset["rpc_url"]
         self.explorer_url = explorer_url or preset["explorer_url"]
         self.contract_address = contract_address or preset["contract_address"]
+        self.deploy_block = preset.get("deploy_block")
         self._custom_rpc = rpc_url is not None
         self._request_timeout = request_timeout
 

--- a/swarm_provenance_mcp/server.py
+++ b/swarm_provenance_mcp/server.py
@@ -2819,6 +2819,33 @@ async def handle_get_provenance_chain(arguments: Dict[str, Any]) -> CallToolResu
 
             def _readonly_traverse():
                 """BFS traversal in a thread to avoid blocking the event loop."""
+                import logging as _log
+
+                _logger = _log.getLogger(__name__)
+
+                # Build in-memory transformation index via cached event scan
+                from .chain.event_cache import get_cache as _get_event_cache
+
+                forward = {}  # original_hex -> [(new_hex, desc)]
+                reverse = {}  # new_hex -> [(original_hex, desc)]
+                deploy_block = provider.deploy_block
+                use_local_index = False
+
+                if deploy_block is not None:
+                    try:
+                        cache = _get_event_cache(
+                            provider.chain, provider.contract_address
+                        )
+                        current_block = provider.web3.eth.block_number
+                        forward, reverse = cache.get_maps(
+                            contract, deploy_block, current_block
+                        )
+                        use_local_index = True
+                    except Exception as e:
+                        _logger.warning(
+                            "Full event scan failed, per-node fallback: %s", e
+                        )
+
                 records = []
                 visited = set()
                 to_visit = [(clean_hash, 0)]
@@ -2850,46 +2877,73 @@ async def handle_get_provenance_chain(arguments: Dict[str, Any]) -> CallToolResu
                             ],
                         )
 
-                        # Enrich transformations with new_data_hash from events
-                        try:
-                            events = contract.get_transformations_from(current_hash)
-                            if events:
-                                enriched = []
-                                for orig_bytes, new_bytes, desc in events:
-                                    new_hash = (
-                                        new_bytes.hex()
-                                        if isinstance(new_bytes, bytes)
-                                        else str(new_bytes)
+                        if use_local_index:
+                            fwd = forward.get(current_hash, [])
+                            if fwd:
+                                record.transformations = [
+                                    ChainTransformation(
+                                        description=desc,
+                                        new_data_hash=nh,
                                     )
-                                    enriched.append(
-                                        ChainTransformation(
-                                            description=desc,
-                                            new_data_hash=new_hash,
+                                    for nh, desc in fwd
+                                ]
+                                for nh, _ in fwd:
+                                    if nh not in visited:
+                                        to_visit.append((nh, depth + 1))
+                            for orig_hex, _ in reverse.get(current_hash, []):
+                                if orig_hex not in visited:
+                                    to_visit.append((orig_hex, depth + 1))
+                        else:
+                            try:
+                                events = contract.get_transformations_from(current_hash)
+                                if events:
+                                    enriched = []
+                                    for orig_bytes, new_bytes, desc in events:
+                                        new_hash = (
+                                            new_bytes.hex()
+                                            if isinstance(new_bytes, bytes)
+                                            else str(new_bytes)
                                         )
-                                    )
-                                    if new_hash not in visited:
-                                        to_visit.append((new_hash, depth + 1))
-                                record.transformations = enriched
-                        except Exception:
-                            for t in record.transformations:
-                                if t.new_data_hash and t.new_data_hash not in visited:
-                                    to_visit.append((t.new_data_hash, depth + 1))
-
-                        # Reverse: find parents
-                        try:
-                            reverse_events = contract.get_transformations_to(
-                                current_hash
-                            )
-                            for orig_bytes, new_bytes, desc in reverse_events:
-                                orig_hash = (
-                                    orig_bytes.hex()
-                                    if isinstance(orig_bytes, bytes)
-                                    else str(orig_bytes)
+                                        enriched.append(
+                                            ChainTransformation(
+                                                description=desc,
+                                                new_data_hash=new_hash,
+                                            )
+                                        )
+                                        if new_hash not in visited:
+                                            to_visit.append((new_hash, depth + 1))
+                                    record.transformations = enriched
+                            except Exception as e:
+                                _logger.warning(
+                                    "Event query failed for %s: %s",
+                                    current_hash,
+                                    e,
                                 )
-                                if orig_hash not in visited:
-                                    to_visit.append((orig_hash, depth + 1))
-                        except Exception:
-                            pass
+                                for t in record.transformations:
+                                    if (
+                                        t.new_data_hash
+                                        and t.new_data_hash not in visited
+                                    ):
+                                        to_visit.append((t.new_data_hash, depth + 1))
+
+                            try:
+                                reverse_events = contract.get_transformations_to(
+                                    current_hash
+                                )
+                                for orig_bytes, new_bytes, desc in reverse_events:
+                                    orig_hash = (
+                                        orig_bytes.hex()
+                                        if isinstance(orig_bytes, bytes)
+                                        else str(orig_bytes)
+                                    )
+                                    if orig_hash not in visited:
+                                        to_visit.append((orig_hash, depth + 1))
+                            except Exception as e:
+                                _logger.warning(
+                                    "Reverse event query failed for %s: %s",
+                                    current_hash,
+                                    e,
+                                )
 
                         records.append(record)
                     except Exception:

--- a/tests/test_event_cache.py
+++ b/tests/test_event_cache.py
@@ -1,0 +1,337 @@
+"""Tests for the TransformationEventCache and singleton registry."""
+
+import threading
+import pytest
+from unittest.mock import MagicMock
+
+from swarm_provenance_mcp.chain.event_cache import (
+    TransformationEventCache,
+    get_cache,
+    clear_registry,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """Clear the singleton registry before each test."""
+    clear_registry()
+    yield
+    clear_registry()
+
+
+class TestTransformationEventCache:
+    """Unit tests for TransformationEventCache."""
+
+    def _make_contract(self, events=None):
+        """Build a mock contract with get_all_transformations."""
+        contract = MagicMock()
+        contract.get_all_transformations.return_value = events or []
+        return contract
+
+    def test_first_call_full_scan(self):
+        """First call should scan from deploy_block to current_block."""
+        parent = bytes.fromhex("aa" * 32)
+        child = bytes.fromhex("bb" * 32)
+        contract = self._make_contract(
+            [
+                (parent, child, "Step 1"),
+            ]
+        )
+
+        cache = TransformationEventCache()
+        forward, reverse = cache.get_maps(contract, deploy_block=100, current_block=500)
+
+        contract.get_all_transformations.assert_called_once_with(
+            from_block=100,
+            to_block=500,
+        )
+        assert "aa" * 32 in forward
+        assert forward["aa" * 32] == [("bb" * 32, "Step 1")]
+        assert "bb" * 32 in reverse
+        assert reverse["bb" * 32] == [("aa" * 32, "Step 1")]
+        assert cache._last_scanned_block == 500
+
+    def test_second_call_incremental(self):
+        """Second call should scan only new blocks and preserve old entries."""
+        parent = bytes.fromhex("aa" * 32)
+        child = bytes.fromhex("bb" * 32)
+        contract = self._make_contract([(parent, child, "Step 1")])
+        cache = TransformationEventCache()
+
+        # First call: full scan
+        cache.get_maps(contract, deploy_block=100, current_block=500)
+        assert contract.get_all_transformations.call_count == 1
+
+        # Add a new event for the incremental scan
+        new_parent = bytes.fromhex("cc" * 32)
+        new_child = bytes.fromhex("dd" * 32)
+        contract.get_all_transformations.return_value = [
+            (new_parent, new_child, "Step 2"),
+        ]
+
+        # Second call: incremental
+        forward, reverse = cache.get_maps(contract, deploy_block=100, current_block=600)
+        assert contract.get_all_transformations.call_count == 2
+        # Should scan from 501 (last + 1)
+        contract.get_all_transformations.assert_called_with(
+            from_block=501,
+            to_block=600,
+        )
+        # New entries present
+        assert "cc" * 32 in forward
+        assert "dd" * 32 in reverse
+        # Old entries preserved
+        assert "aa" * 32 in forward
+        assert forward["aa" * 32] == [("bb" * 32, "Step 1")]
+        assert "bb" * 32 in reverse
+        assert cache._last_scanned_block == 600
+
+    def test_no_new_blocks(self):
+        """No scan when current_block == last_scanned_block."""
+        contract = self._make_contract([])
+        cache = TransformationEventCache()
+
+        cache.get_maps(contract, deploy_block=100, current_block=500)
+        assert contract.get_all_transformations.call_count == 1
+
+        # Same block — no scan
+        cache.get_maps(contract, deploy_block=100, current_block=500)
+        assert contract.get_all_transformations.call_count == 1
+
+    def test_empty_events(self):
+        """Works with no events at all."""
+        contract = self._make_contract([])
+        cache = TransformationEventCache()
+
+        forward, reverse = cache.get_maps(contract, deploy_block=0, current_block=1000)
+        assert forward == {}
+        assert reverse == {}
+        assert cache._last_scanned_block == 1000
+
+    def test_scan_failure_propagates(self):
+        """Scan failure should propagate so caller can fall back."""
+        contract = MagicMock()
+        contract.get_all_transformations.side_effect = Exception("RPC down")
+        cache = TransformationEventCache()
+
+        with pytest.raises(Exception, match="RPC down"):
+            cache.get_maps(contract, deploy_block=100, current_block=500)
+
+        # Cache should not have recorded a last_scanned_block
+        assert cache._last_scanned_block is None
+
+    def test_multiple_events_same_original(self):
+        """Multiple transformations from the same original hash."""
+        parent = bytes.fromhex("aa" * 32)
+        child1 = bytes.fromhex("bb" * 32)
+        child2 = bytes.fromhex("cc" * 32)
+        contract = self._make_contract(
+            [
+                (parent, child1, "Step 1"),
+                (parent, child2, "Step 2"),
+            ]
+        )
+
+        cache = TransformationEventCache()
+        forward, reverse = cache.get_maps(contract, deploy_block=0, current_block=100)
+
+        assert len(forward["aa" * 32]) == 2
+        assert ("bb" * 32, "Step 1") in forward["aa" * 32]
+        assert ("cc" * 32, "Step 2") in forward["aa" * 32]
+
+    def test_thread_safety(self):
+        """Concurrent get_maps calls should not corrupt state."""
+        parent = bytes.fromhex("aa" * 32)
+        child = bytes.fromhex("bb" * 32)
+
+        call_count = 0
+
+        def slow_scan(from_block, to_block):
+            nonlocal call_count
+            call_count += 1
+            return [(parent, child, f"Call {call_count}")]
+
+        contract = MagicMock()
+        contract.get_all_transformations.side_effect = slow_scan
+
+        cache = TransformationEventCache()
+        results = []
+        errors = []
+
+        def worker(block):
+            try:
+                fwd, rev = cache.get_maps(contract, deploy_block=0, current_block=block)
+                results.append((fwd, rev))
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker, args=(1000 + i,)) for i in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors
+        # All threads should get consistent forward/reverse maps
+        for fwd, rev in results:
+            assert "aa" * 32 in fwd
+            assert "bb" * 32 in rev
+
+    def test_recovery_after_failed_scan(self):
+        """After a failed scan, next call should retry from same block."""
+        parent = bytes.fromhex("aa" * 32)
+        child = bytes.fromhex("bb" * 32)
+        contract = MagicMock()
+        cache = TransformationEventCache()
+
+        # First call succeeds
+        contract.get_all_transformations.return_value = [
+            (parent, child, "Step 1"),
+        ]
+        cache.get_maps(contract, deploy_block=100, current_block=500)
+        assert cache._last_scanned_block == 500
+
+        # Second call fails
+        contract.get_all_transformations.side_effect = Exception("RPC down")
+        with pytest.raises(Exception, match="RPC down"):
+            cache.get_maps(contract, deploy_block=100, current_block=600)
+
+        # last_scanned_block should still be 500 (not advanced)
+        assert cache._last_scanned_block == 500
+
+        # Third call succeeds — should retry from 501
+        contract.get_all_transformations.side_effect = None
+        contract.get_all_transformations.return_value = []
+        forward, reverse = cache.get_maps(contract, deploy_block=100, current_block=700)
+
+        contract.get_all_transformations.assert_called_with(
+            from_block=501,
+            to_block=700,
+        )
+        # Old entries still present
+        assert "aa" * 32 in forward
+        assert cache._last_scanned_block == 700
+
+
+class TestReadonlyPathCacheIntegration:
+    """Test the server.py _readonly_traverse path uses the cache."""
+
+    async def test_readonly_traverse_uses_cache(self):
+        """No-wallet path with deploy_block set should use event cache."""
+        from swarm_provenance_mcp.server import create_server
+
+        parent_hash = "aa" * 32
+        child_hash = "bb" * 32
+        TEST_CONTRACT = "0x9a3c6F47B69211F05891CCb7aD33596290b9fE64"
+
+        server = create_server()
+
+        mock_provider = MagicMock()
+        mock_provider.web3 = MagicMock()
+        mock_provider.web3.eth.block_number = 40_000_000
+        mock_provider.contract_address = TEST_CONTRACT
+        mock_provider.chain = "base-sepolia"
+        mock_provider.deploy_block = 37_562_100
+
+        mock_contract = MagicMock()
+        # Event scan returns one transformation
+        mock_contract.get_all_transformations.return_value = [
+            (bytes.fromhex(parent_hash), bytes.fromhex(child_hash), "Anonymized"),
+        ]
+        # Both hashes are registered
+        zero_address = "0x" + "0" * 40
+        owner = "0x1234567890abcdef1234567890abcdef12345678"
+
+        def get_data_record(h):
+            h_hex = h.hex() if isinstance(h, bytes) else str(h)
+            if h_hex == parent_hash:
+                return (
+                    bytes.fromhex(parent_hash),
+                    owner,
+                    1700000000,
+                    "original",
+                    [],
+                    [],
+                    0,
+                )
+            if h_hex == child_hash:
+                return (
+                    bytes.fromhex(child_hash),
+                    owner,
+                    1700001000,
+                    "derived",
+                    [],
+                    [],
+                    0,
+                )
+            return (bytes(32), zero_address, 0, "", [], [], 0)
+
+        mock_contract.get_data_record.side_effect = get_data_record
+
+        from unittest.mock import patch
+        from tests.test_tool_execution import call_tool_directly
+
+        with (
+            patch("swarm_provenance_mcp.server.CHAIN_AVAILABLE", True),
+            patch("swarm_provenance_mcp.server.chain_client", None),
+            patch(
+                "swarm_provenance_mcp.chain.provider.ChainProvider",
+                return_value=mock_provider,
+            ),
+            patch(
+                "swarm_provenance_mcp.chain.contract.DataProvenanceContract",
+                return_value=mock_contract,
+            ),
+        ):
+            result = await call_tool_directly(
+                server,
+                "get_provenance_chain",
+                {"swarm_hash": parent_hash},
+            )
+
+        assert not result.isError
+        text = result.content[0].text
+        assert "2 entries" in text
+        assert parent_hash in text
+        assert child_hash in text
+
+        # Verify it used the full scan (cache path), not per-node queries
+        mock_contract.get_all_transformations.assert_called_once_with(
+            from_block=37_562_100,
+            to_block=40_000_000,
+        )
+        mock_contract.get_transformations_from.assert_not_called()
+        mock_contract.get_transformations_to.assert_not_called()
+
+
+class TestSingletonRegistry:
+    """Tests for the get_cache singleton registry."""
+
+    def test_same_key_returns_same_instance(self):
+        """Same (chain, address) should return the same cache."""
+        c1 = get_cache("base-sepolia", "0xABC")
+        c2 = get_cache("base-sepolia", "0xABC")
+        assert c1 is c2
+
+    def test_different_key_returns_different_instance(self):
+        """Different chain or address should return different caches."""
+        c1 = get_cache("base-sepolia", "0xABC")
+        c2 = get_cache("base", "0xABC")
+        c3 = get_cache("base-sepolia", "0xDEF")
+        assert c1 is not c2
+        assert c1 is not c3
+
+    def test_case_insensitive_address(self):
+        """Address matching should be case-insensitive."""
+        c1 = get_cache("base-sepolia", "0xAbCdEf")
+        c2 = get_cache("base-sepolia", "0xABCDEF")
+        c3 = get_cache("base-sepolia", "0xabcdef")
+        assert c1 is c2
+        assert c1 is c3
+
+    def test_clear_registry(self):
+        """clear_registry should remove all cached instances."""
+        c1 = get_cache("base-sepolia", "0xABC")
+        clear_registry()
+        c2 = get_cache("base-sepolia", "0xABC")
+        assert c1 is not c2

--- a/tests/test_tool_execution.py
+++ b/tests/test_tool_execution.py
@@ -3785,6 +3785,8 @@ class TestProvenanceChainEventTraversal:
 
         client = ChainClient.__new__(ChainClient)
         client._contract = MagicMock()
+        client._provider = MagicMock()
+        client._provider.deploy_block = None  # Force per-node fallback path
         # Event query fails
         client._contract.get_transformations_from.side_effect = Exception("RPC error")
         client._contract.get_transformations_to.side_effect = Exception("RPC error")
@@ -3823,6 +3825,8 @@ class TestProvenanceChainEventTraversal:
 
         client = ChainClient.__new__(ChainClient)
         client._contract = MagicMock()
+        client._provider = MagicMock()
+        client._provider.deploy_block = None  # Force per-node scanning path
 
         parent_hash = "aa" * 32
         leaf_hash = "bb" * 32
@@ -3876,6 +3880,254 @@ class TestProvenanceChainEventTraversal:
         assert len(chain) == 2
         assert leaf_hash in hashes
         assert parent_hash in hashes
+
+    async def test_full_history_scan_with_deploy_block(self):
+        """When deploy_block is set, should do a single full scan instead of per-node queries."""
+        from swarm_provenance_mcp.chain.client import ChainClient
+        from swarm_provenance_mcp.chain.exceptions import DataNotRegisteredError
+        from swarm_provenance_mcp.chain.models import (
+            ChainProvenanceRecord, ChainTransformation, DataStatusEnum,
+        )
+        from swarm_provenance_mcp.chain.event_cache import clear_registry
+        clear_registry()
+
+        parent_hash = "aa" * 32
+        child_hash = "bb" * 32
+
+        client = ChainClient.__new__(ChainClient)
+        client._contract = MagicMock()
+        client._provider = MagicMock()
+        client._provider.deploy_block = 37_562_100  # Known deploy block
+        client._provider.chain = "base-sepolia"
+        client._provider.contract_address = "0xTEST_FULL_SCAN"
+        client._provider.web3.eth.block_number = 40_000_000
+
+        # get_all_transformations returns all events in one scan
+        client._contract.get_all_transformations.return_value = [
+            (bytes.fromhex(parent_hash), bytes.fromhex(child_hash), "Anonymized"),
+        ]
+
+        parent_record = ChainProvenanceRecord(
+            data_hash=parent_hash,
+            owner="0xOWNER",
+            timestamp=1700000000,
+            data_type="original",
+            status=DataStatusEnum(0),
+            transformations=[],
+            accessors=[],
+        )
+        child_record = ChainProvenanceRecord(
+            data_hash=child_hash,
+            owner="0xOWNER",
+            timestamp=1700001000,
+            data_type="derived",
+            status=DataStatusEnum(0),
+            transformations=[],
+            accessors=[],
+        )
+
+        def get_side_effect(h):
+            if h == parent_hash:
+                return parent_record
+            if h == child_hash:
+                return child_record
+            raise DataNotRegisteredError("not found", data_hash=h)
+
+        client.get = MagicMock(side_effect=get_side_effect)
+
+        chain = client.get_provenance_chain(parent_hash)
+        hashes = [r.data_hash for r in chain]
+        assert len(chain) == 2
+        assert parent_hash in hashes
+        assert child_hash in hashes
+
+        # Verify it used get_all_transformations (full scan) NOT per-node queries
+        client._contract.get_all_transformations.assert_called_once_with(
+            from_block=37_562_100,
+            to_block=40_000_000,
+        )
+        client._contract.get_transformations_from.assert_not_called()
+        client._contract.get_transformations_to.assert_not_called()
+
+    async def test_full_history_scan_enriches_transformations(self):
+        """Full history scan should enrich record.transformations with new_data_hash."""
+        from swarm_provenance_mcp.chain.client import ChainClient
+        from swarm_provenance_mcp.chain.exceptions import DataNotRegisteredError
+        from swarm_provenance_mcp.chain.models import (
+            ChainProvenanceRecord, ChainTransformation, DataStatusEnum,
+        )
+        from swarm_provenance_mcp.chain.event_cache import clear_registry
+        clear_registry()
+
+        root_hash = "aa" * 32
+        child_hash = "bb" * 32
+
+        client = ChainClient.__new__(ChainClient)
+        client._contract = MagicMock()
+        client._provider = MagicMock()
+        client._provider.deploy_block = 100
+        client._provider.chain = "base-sepolia"
+        client._provider.contract_address = "0xTEST_ENRICH"
+        client._provider.web3.eth.block_number = 50_000
+
+        client._contract.get_all_transformations.return_value = [
+            (bytes.fromhex(root_hash), bytes.fromhex(child_hash), "Step 1"),
+        ]
+
+        root_record = ChainProvenanceRecord(
+            data_hash=root_hash,
+            owner="0xOWNER",
+            timestamp=1700000000,
+            data_type="test",
+            status=DataStatusEnum(0),
+            transformations=[ChainTransformation(description="Step 1")],
+            accessors=[],
+        )
+
+        def get_side_effect(h):
+            if h == root_hash:
+                return root_record
+            raise DataNotRegisteredError("not found", data_hash=h)
+
+        client.get = MagicMock(side_effect=get_side_effect)
+
+        chain = client.get_provenance_chain(root_hash)
+        assert len(chain) == 1
+        # Transformation should be enriched with new_data_hash from the event index
+        t = chain[0].transformations[0]
+        assert t.new_data_hash == child_hash
+        assert t.description == "Step 1"
+
+    async def test_full_scan_fallback_on_error(self):
+        """If get_all_transformations fails, should fall back to per-node scanning."""
+        from swarm_provenance_mcp.chain.client import ChainClient
+        from swarm_provenance_mcp.chain.exceptions import DataNotRegisteredError
+        from swarm_provenance_mcp.chain.models import (
+            ChainProvenanceRecord, ChainTransformation, DataStatusEnum,
+        )
+        from swarm_provenance_mcp.chain.event_cache import clear_registry
+        clear_registry()
+
+        hash_a = "aa" * 32
+
+        client = ChainClient.__new__(ChainClient)
+        client._contract = MagicMock()
+        client._provider = MagicMock()
+        client._provider.deploy_block = 100  # Deploy block set but scan fails
+        client._provider.chain = "base-sepolia"
+        client._provider.contract_address = "0xTEST_FALLBACK"
+        client._provider.web3.eth.block_number = 50_000
+
+        # Full scan fails
+        client._contract.get_all_transformations.side_effect = Exception("RPC down")
+        # Per-node fallback works
+        client._contract.get_transformations_from.return_value = []
+        client._contract.get_transformations_to.return_value = []
+
+        record = ChainProvenanceRecord(
+            data_hash=hash_a,
+            owner="0xOWNER",
+            timestamp=1700000000,
+            data_type="test",
+            status=DataStatusEnum(0),
+            transformations=[],
+            accessors=[],
+        )
+
+        def get_side_effect(h):
+            if h == hash_a:
+                return record
+            raise DataNotRegisteredError("not found", data_hash=h)
+
+        client.get = MagicMock(side_effect=get_side_effect)
+
+        chain = client.get_provenance_chain(hash_a)
+        assert len(chain) == 1
+        # Should have fallen back to per-node queries
+        client._contract.get_transformations_from.assert_called()
+
+
+class TestGetAllTransformations:
+    """Test contract.get_all_transformations method."""
+
+    def test_returns_all_events_unfiltered(self):
+        from swarm_provenance_mcp.chain.contract import DataProvenanceContract
+
+        contract = DataProvenanceContract.__new__(DataProvenanceContract)
+        contract._web3 = MagicMock()
+        contract._web3.eth.block_number = 5000
+        contract._contract = MagicMock()
+
+        mock_event1 = MagicMock()
+        mock_event1.args.originalDataHash = b'\xaa' * 32
+        mock_event1.args.newDataHash = b'\xbb' * 32
+        mock_event1.args.transformation = "Step 1"
+
+        mock_event2 = MagicMock()
+        mock_event2.args.originalDataHash = b'\xbb' * 32
+        mock_event2.args.newDataHash = b'\xcc' * 32
+        mock_event2.args.transformation = "Step 2"
+
+        contract._contract.events.DataTransformed.get_logs.return_value = [
+            mock_event1, mock_event2,
+        ]
+
+        results = contract.get_all_transformations(from_block=0, to_block=5000)
+        assert len(results) == 2
+        assert results[0][2] == "Step 1"
+        assert results[1][2] == "Step 2"
+
+        # Verify no argument_filters were passed (unfiltered scan)
+        call_kw = contract._contract.events.DataTransformed.get_logs.call_args
+        assert "argument_filters" not in call_kw.kwargs
+
+    def test_uses_latest_block_when_to_block_omitted(self):
+        from swarm_provenance_mcp.chain.contract import DataProvenanceContract
+
+        contract = DataProvenanceContract.__new__(DataProvenanceContract)
+        contract._web3 = MagicMock()
+        contract._web3.eth.block_number = 9999
+        contract._contract = MagicMock()
+        contract._contract.events.DataTransformed.get_logs.return_value = []
+
+        contract.get_all_transformations(from_block=5000)
+        call_kw = contract._contract.events.DataTransformed.get_logs.call_args
+        assert call_kw.kwargs["to_block"] == 9999
+
+    def test_empty_range_returns_empty(self):
+        from swarm_provenance_mcp.chain.contract import DataProvenanceContract
+
+        contract = DataProvenanceContract.__new__(DataProvenanceContract)
+        contract._web3 = MagicMock()
+        contract._web3.eth.block_number = 100
+        contract._contract = MagicMock()
+        contract._contract.events.DataTransformed.get_logs.return_value = []
+
+        results = contract.get_all_transformations(from_block=0, to_block=100)
+        assert results == []
+
+
+class TestDeployBlock:
+    """Test deploy_block in chain presets."""
+
+    def test_base_sepolia_has_deploy_block(self):
+        from swarm_provenance_mcp.chain.provider import CHAIN_PRESETS
+        assert CHAIN_PRESETS["base-sepolia"]["deploy_block"] == 37_562_100
+
+    def test_base_deploy_block_is_none(self):
+        from swarm_provenance_mcp.chain.provider import CHAIN_PRESETS
+        assert CHAIN_PRESETS["base"]["deploy_block"] is None
+
+    def test_provider_exposes_deploy_block(self):
+        from swarm_provenance_mcp.chain.provider import ChainProvider
+        with patch("swarm_provenance_mcp.chain.provider._import_web3") as mock_w3:
+            mock_web3_cls = MagicMock()
+            mock_w3.return_value = mock_web3_cls
+            provider = ChainProvider(
+                chain="base-sepolia",
+                contract_address="0x9a3c6F47B69211F05891CCb7aD33596290b9fE64",
+            )
+            assert provider.deploy_block == 37_562_100
 
 
 class TestProvenanceChainWorkflowPrompt:


### PR DESCRIPTION
## Summary

- Adds `TransformationEventCache` — a thread-safe singleton that caches `DataTransformed` event logs in memory, keyed by `(chain, contract_address)`
- First call does a full scan from deploy block (~20s, same as before); subsequent calls scan only new blocks since last scan (<1s)
- Both `ChainClient.get_provenance_chain()` and the read-only `_readonly_traverse()` fallback share the same cache instance
- Includes foundational changes: `deploy_block` in chain presets, `get_all_transformations()` unfiltered event query, `_get_logs_chunked` support for `None` argument_filters

## Test plan

- [x] 13 new tests in `test_event_cache.py` — full scan, incremental, no-new-blocks, empty events, failure recovery, thread safety, multiple events, readonly path integration, singleton registry (identity, case-insensitive, different keys, clear)
- [x] 3 existing tests updated for new `to_block` parameter and explicit mock provider setup
- [x] Full suite: 441 passed, 7 skipped (Docker), 0 failures
- [x] `black --check` and `ruff check` clean on changed files

Closes #109