### PR TITLE
fix: auto-publish Docker image on push to main

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,6 +2,7 @@ name: Build and Publish Docker Image
 
 on:
   push:
+    branches: [ main ]
     tags:
       - "v*"
   workflow_dispatch:
@@ -16,6 +17,10 @@ jobs:
     permissions:
       contents: read
       packages: write
+
+    concurrency:
+      group: docker-publish-${{ github.ref }}
+      cancel-in-progress: true
 
     steps:
       - name: Checkout repository
@@ -43,6 +48,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,prefix=sha-,format=short
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6

--- a/docker/mcp-registry/readme.md
+++ b/docker/mcp-registry/readme.md
@@ -20,12 +20,18 @@ To submit this server to the Docker MCP Registry:
 
 ## Prerequisites
 
-The Docker image must be published to GHCR first:
+The Docker image must be published to GHCR first. The image is **automatically rebuilt** on every push to `main` and on version tags:
+
+| Trigger | Tags produced |
+|---------|---------------|
+| Push to `main` | `latest`, `sha-<7char>` |
+| Tag `v1.2.3` | `1.2.3`, `1.2`, `latest`, `sha-<7char>` |
 
 ```bash
-# Tag a release to trigger the publish workflow
+# Force a publish via version tag
 git tag v0.1.0
 git push origin v0.1.0
 ```
 
-The image will be available at `ghcr.io/datafund/swarm-provenance-mcp:latest`.
+The image is available at `ghcr.io/datafund/swarm-provenance-mcp:latest`.
+Pin a specific build with `ghcr.io/datafund/swarm-provenance-mcp:sha-<commit>`.


### PR DESCRIPTION
## Summary

- Add `branches: [ main ]` push trigger to `docker-publish.yml` so the `latest` image is rebuilt on every merge to main — not just on `v*` tags
- Add concurrency group (`cancel-in-progress: true`) to save CI minutes on rapid pushes
- Add `type=sha,prefix=sha-,format=short` tag for commit-level traceability
- Update `docker/mcp-registry/readme.md` to document auto-publish behavior and tag scheme

## Context

The published `ghcr.io/datafund/swarm-provenance-mcp:latest` was built from a stale feature branch commit (`c119cf5`) that had `capabilities={}` hardcoded. The fix has been on `main` since `fbddd2b`, but the workflow only triggered on `v*` tags — so `latest` was never rebuilt.

### Tag behavior per trigger

| Trigger | Tags produced |
|---------|---------------|
| Push to `main` | `latest`, `sha-{7char}` |
| Tag `v1.2.3` | `1.2.3`, `1.2`, `latest`, `sha-{7char}` |
| `workflow_dispatch` | `latest`, `sha-{7char}` |

## Test plan

- [ ] PR merges to `development`, then `development` merges to `main`
- [ ] Push to `main` triggers the Docker publish workflow in GitHub Actions
- [ ] Pull `ghcr.io/datafund/swarm-provenance-mcp:latest` and verify `capabilities.tools` is present in initialize response
- [ ] Confirm `sha-` tag exists on GHCR alongside `latest`

Closes #126