### PR TITLE
docs: clarify Docker image is GHCR-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ cp .env.example .env
 
 Run the MCP server in a container with no local dependencies.
 
+> **Registry**: The pre-built image is published to **GitHub Container Registry** only — always use the full `ghcr.io/` prefix. It is **not** available on Docker Hub.
+
 **Quick start** (pre-built image):
 ```bash
 docker pull ghcr.io/datafund/swarm-provenance-mcp:latest


### PR DESCRIPTION
## Summary

- Add a note to the Docker quick start section in README.md clarifying the image is published to GitHub Container Registry only, not Docker Hub
- Prevents silent failures when users try Docker Hub-style image names like `datafund/swarm_provenance_mcp`

Closes #124